### PR TITLE
Increased origName buffer size to accommodate larger descriptions

### DIFF
--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -269,7 +269,7 @@ void SubstituteNameVariables(UnitItemInfo* uInfo,
 	const string& action_name,
 	BOOL          bLimit)
 {
-	char origName[175], sockets[4], code[5], ilvl[4], alvl[4], craftalvl[4], runename[16] = "", runenum[4] = "0";
+	char origName[235], sockets[4], code[5], ilvl[4], alvl[4], craftalvl[4], runename[16] = "", runenum[4] = "0";
 	char gemtype[16] = "", gemlevel[16] = "", sellValue[16] = "", statVal[16] = "", qty[4] = "";
 	char lvlreq[4], wpnspd[4], rangeadder[4];
 


### PR DESCRIPTION
Increased origName buffer size from 175 to 235 to accommodate descriptions that utilize many colors

The current limit of 175 characters includes 3 characters per color change - this severely limits descriptions which use many color changes such as those that refer to gems and runes with colored symbols to describe crafting recipes. I determined 235 characters would be the most I'd use to describe recipes with symbols in this way, but if that is too excessive for performance reasons, even an increase to 196 would be a substantial improvement.