### PR TITLE
Add add'l item details to export

### DIFF
--- a/BH/Modules/StashExport/StashExport.cpp
+++ b/BH/Modules/StashExport/StashExport.cpp
@@ -220,6 +220,27 @@ void StashExport::GetItemInfo(UnitAny* pItem, JSONObject* pBuffer) {
 	pBuffer->set("quality", std::string(QUALITY_NAMES[pItem->pItemData->dwQuality]));
 	pBuffer->set("iLevel", (int)pItem->pItemData->dwItemLevel);
 
+	for (int j = 0; j < 6; j++)
+	{
+		const auto location = ITEM_LOCATIONS[j];
+		if (location.id != pItem->pItemData->ItemLocation) {
+			continue;
+		}
+
+		if (location.id == STORAGE_NULL) {
+			if (pItem->pItemData->NodePage == NODEPAGE_EQUIP) {
+				pBuffer->set("location", std::string("Equip"));
+			}
+
+			break;
+		}
+		else {
+			pBuffer->set("location", location.name);
+		}
+
+		break;
+	}
+
 	char cCode[] = {
 		txt->szCode[0],
 		txt->szCode[1],

--- a/BH/Modules/StashExport/StashExport.cpp
+++ b/BH/Modules/StashExport/StashExport.cpp
@@ -244,6 +244,7 @@ void StashExport::GetItemInfo(UnitAny* pItem, JSONObject* pBuffer) {
 		pBuffer->set("unidentified", !checkFlag(pItem, ITEM_IDENTIFIED));
 		pBuffer->set("sockets", (int)D2COMMON_GetUnitStat(pItem, STAT_SOCKETS, 0));
 		pBuffer->set("defense", (int)D2COMMON_GetUnitStat(pItem, STAT_DEFENSE, 0));
+		pBuffer->set("quantity", (int)D2COMMON_GetUnitStat(pItem, STAT_AMMOQUANTITY, 0));
 
 		auto statsObject = new JSONArray();
 		pBuffer->set("stats", statsObject);

--- a/BH/Modules/StashExport/StashExport.h
+++ b/BH/Modules/StashExport/StashExport.h
@@ -54,3 +54,4 @@ char* QUALITY_NAMES[];
 IdNamePair NODE_PAGES[];
 IdNamePair CLASS_NAMES[];
 IdNamePair SKILL_TABS[];
+IdNamePair ITEM_LOCATIONS[];


### PR DESCRIPTION
- Adds "Quantity" to help capture the amount of runes/gems/etc in a stack.
- Adds "location" to help identify where the item is
  - Handles case where the item is actually Equipped but it's location is NULL.
  - Other cases of NULL include if the gem/rune/jewel is inside of a socket, the property is skipped in this case.