### PR TITLE
Add automod to loot filter types. Add "Between" operator that supports value ranges

### DIFF
--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1810,13 +1810,8 @@ bool AutomodCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	{
 		return false;
 	}
-	if (itemData->wAutoPrefix == automodID)
-	{
-		return IntegerCompare(itemData->wAutoPrefix, operation, automodID);
-	}
 
-	return IntegerCompare(-1, operation, automodID);
-
+	return IntegerCompare(itemData->wAutoPrefix, operation, automodID);
 }
 
 bool AutomodCondition::EvaluateInternalFromPacket(ItemInfo* info,

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1163,8 +1163,8 @@ void Condition::BuildConditions(vector<Condition*>& conditions,
 	else if (key.compare(0, 5, "DRUID") == 0) { Condition::AddOperand(conditions, new CharacterClassCondition(EQUAL, 5)); }
 	else if (key.compare(0, 8, "ASSASSIN") == 0) { Condition::AddOperand(conditions, new CharacterClassCondition(EQUAL, 6)); }
 	else if (key.compare(0, 9, "CRAFTALVL") == 0) { Condition::AddOperand(conditions, new CraftLevelCondition(operation, value)); }
-	else if (key.compare(0, 6, "PREFIX") == 0) { Condition::AddOperand(conditions, new MagicPrefixCondition(operation, value)); }
-	else if (key.compare(0, 6, "SUFFIX") == 0) { Condition::AddOperand(conditions, new MagicSuffixCondition(operation, value)); }
+	else if (key.compare(0, 6, "PREFIX") == 0) { Condition::AddOperand(conditions, new MagicPrefixCondition(operation, value, value2)); }
+	else if (key.compare(0, 6, "SUFFIX") == 0) { Condition::AddOperand(conditions, new MagicSuffixCondition(operation, value, value2)); }
 	else if (key.compare(0, 7, "AUTOMOD") == 0) { Condition::AddOperand(conditions, new AutomodCondition(operation, value)); }
 	else if (key.compare(0, 5, "MAPID") == 0) { Condition::AddOperand(conditions, new MapIdCondition(operation, value)); }
 	else if (key.compare(0, 5, "CRAFT") == 0) { Condition::AddOperand(conditions, new QualityCondition(ITEM_QUALITY_CRAFT)); }
@@ -1753,20 +1753,25 @@ bool MagicPrefixCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	{
 		return false;
 	}
-	if (itemData->wPrefix[0] == prefixID)
+	if (operation == GREATER_THAN || operation == LESS_THAN)
 	{
-		return IntegerCompare(itemData->wPrefix[0], operation, prefixID);
-	}
-	if (itemData->wPrefix[1] == prefixID)
-	{
-		return IntegerCompare(itemData->wPrefix[1], operation, prefixID);
-	}
-	if (itemData->wPrefix[2] == prefixID)
-	{
-		return IntegerCompare(itemData->wPrefix[2], operation, prefixID);
+		return false;
 	}
 
-	return IntegerCompare(-1, operation, prefixID);
+	if ((itemData->wPrefix[0] > 0) ? IntegerCompare(itemData->wPrefix[0], operation, prefixID1, prefixID2) : false)
+	{
+		return true;
+	}
+	if ((itemData->wPrefix[1] > 0) ? IntegerCompare(itemData->wPrefix[1], operation, prefixID1, prefixID2) : false)
+	{
+		return true;
+	}
+	if ((itemData->wPrefix[2] > 0) ? IntegerCompare(itemData->wPrefix[2], operation, prefixID1, prefixID2) : false)
+	{
+		return true;
+	}
+
+	return false;
 }
 
 bool MagicPrefixCondition::EvaluateInternalFromPacket(ItemInfo* info,
@@ -1778,7 +1783,7 @@ bool MagicPrefixCondition::EvaluateInternalFromPacket(ItemInfo* info,
 		return false;
 	}
 
-	return IntegerCompare(-1, operation, prefixID);
+	return IntegerCompare(-1, operation, prefixID1);
 }
 
 bool MagicSuffixCondition::EvaluateInternal(UnitItemInfo* uInfo,
@@ -1791,20 +1796,25 @@ bool MagicSuffixCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	{
 		return false;
 	}
-	if (itemData->wSuffix[0] == suffixID)
+	if (operation == GREATER_THAN || operation == LESS_THAN)
 	{
-		return IntegerCompare(itemData->wSuffix[0], operation, suffixID);
-	}
-	if (itemData->wSuffix[1] == suffixID)
-	{
-		return IntegerCompare(itemData->wSuffix[1], operation, suffixID);
-	}
-	if (itemData->wSuffix[2] == suffixID)
-	{
-		return IntegerCompare(itemData->wSuffix[2], operation, suffixID);
+		return false;
 	}
 
-	return IntegerCompare(-1, operation, suffixID);
+	if ((itemData->wSuffix[0] > 0) ? IntegerCompare(itemData->wSuffix[0], operation, suffixID1, suffixID2) : false)
+	{
+		return true;
+	}
+	if ((itemData->wSuffix[1] > 0) ? IntegerCompare(itemData->wSuffix[1], operation, suffixID1, suffixID2) : false)
+	{
+		return true;
+	}
+	if ((itemData->wSuffix[2] > 0) ? IntegerCompare(itemData->wSuffix[2], operation, suffixID1, suffixID2) : false)
+	{
+		return true;
+	}
+
+	return false;
 }
 
 bool MagicSuffixCondition::EvaluateInternalFromPacket(ItemInfo* info,
@@ -1816,7 +1826,7 @@ bool MagicSuffixCondition::EvaluateInternalFromPacket(ItemInfo* info,
 		return false;
 	}
 
-	return IntegerCompare(-1, operation, suffixID);
+	return IntegerCompare(-1, operation, suffixID1, suffixID2);
 }
 
 bool AutomodCondition::EvaluateInternal(UnitItemInfo* uInfo,

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1108,7 +1108,7 @@ void Condition::BuildConditions(vector<Condition*>& conditions,
 		else { break; }
 	}
 	if (i < (int)(token.length() - 1)) { token.erase(i + 1, string::npos); }
-	
+
 	size_t delPos = token.find_first_of(tokenDelims);
 	string key;
 	string delim = "";
@@ -1783,7 +1783,7 @@ bool MagicPrefixCondition::EvaluateInternalFromPacket(ItemInfo* info,
 		return false;
 	}
 
-	return IntegerCompare(-1, operation, prefixID1);
+	return false;
 }
 
 bool MagicSuffixCondition::EvaluateInternal(UnitItemInfo* uInfo,
@@ -1826,7 +1826,7 @@ bool MagicSuffixCondition::EvaluateInternalFromPacket(ItemInfo* info,
 		return false;
 	}
 
-	return IntegerCompare(-1, operation, suffixID1, suffixID2);
+	return false;
 }
 
 bool AutomodCondition::EvaluateInternal(UnitItemInfo* uInfo,
@@ -1851,7 +1851,7 @@ bool AutomodCondition::EvaluateInternalFromPacket(ItemInfo* info,
 	{
 		return false;
 	}
-	return IntegerCompare(-1, operation, automodID);
+	return false;
 }
 
 bool CharacterClassCondition::EvaluateInternal(UnitItemInfo* uInfo,

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1146,6 +1146,7 @@ void Condition::BuildConditions(vector<Condition*>& conditions,
 	else if (key.compare(0, 9, "CRAFTALVL") == 0) { Condition::AddOperand(conditions, new CraftLevelCondition(operation, value)); }
 	else if (key.compare(0, 6, "PREFIX") == 0) { Condition::AddOperand(conditions, new MagicPrefixCondition(operation, value)); }
 	else if (key.compare(0, 6, "SUFFIX") == 0) { Condition::AddOperand(conditions, new MagicSuffixCondition(operation, value)); }
+	else if (key.compare(0, 7, "AUTOMOD") == 0) { Condition::AddOperand(conditions, new AutomodCondition(operation, value)); }
 	else if (key.compare(0, 5, "MAPID") == 0) { Condition::AddOperand(conditions, new MapIdCondition(operation, value)); }
 	else if (key.compare(0, 5, "CRAFT") == 0) { Condition::AddOperand(conditions, new QualityCondition(ITEM_QUALITY_CRAFT)); }
 	else if (key.compare(0, 2, "RW") == 0) { Condition::AddOperand(conditions, new FlagsCondition(ITEM_RUNEWORD)); }
@@ -1799,6 +1800,35 @@ bool MagicSuffixCondition::EvaluateInternalFromPacket(ItemInfo* info,
 	return IntegerCompare(-1, operation, suffixID);
 }
 
+bool AutomodCondition::EvaluateInternal(UnitItemInfo* uInfo,
+	Condition* arg1,
+	Condition* arg2)
+{
+	auto itemData = uInfo->item->pItemData;
+
+	if ((itemData->dwQuality == ITEM_QUALITY_MAGIC || itemData->dwQuality == ITEM_QUALITY_RARE) && !(itemData->dwFlags & ITEM_IDENTIFIED))
+	{
+		return false;
+	}
+	if (itemData->wAutoPrefix == automodID)
+	{
+		return IntegerCompare(itemData->wAutoPrefix, operation, automodID);
+	}
+
+	return IntegerCompare(-1, operation, automodID);
+
+}
+
+bool AutomodCondition::EvaluateInternalFromPacket(ItemInfo* info,
+	Condition* arg1,
+	Condition* arg2)
+{
+	if ((info->quality == ITEM_QUALITY_MAGIC || info->quality == ITEM_QUALITY_RARE) && !(info->identified))
+	{
+		return false;
+	}
+	return IntegerCompare(-1, operation, automodID);
+}
 
 bool CharacterClassCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	Condition* arg1,

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -523,13 +523,16 @@ class MagicPrefixCondition : public Condition
 {
 public:
 	MagicPrefixCondition(BYTE op,
-		unsigned int prefix) : prefixID(prefix),
+		unsigned int prefix1,
+		unsigned int prefix2) : prefixID1(prefix1),
+		prefixID2(prefix2),
 		operation(op) {
 		conditionType = CT_Operand;
 	};
 private:
 	BYTE operation;
-	unsigned int prefixID;
+	unsigned int prefixID1;
+	unsigned int prefixID2;
 	bool EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);
@@ -542,13 +545,16 @@ class MagicSuffixCondition : public Condition
 {
 public:
 	MagicSuffixCondition(BYTE op,
-		unsigned int suffix) : suffixID(suffix),
+		unsigned int suffix1,
+		unsigned int suffix2) : suffixID1(suffix1),
+		suffixID2(suffix2),
 		operation(op) {
 		conditionType = CT_Operand;
 	};
 private:
 	BYTE operation;
-	unsigned int suffixID;
+	unsigned int suffixID1;
+	unsigned int suffixID2;
 	bool EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -500,6 +500,25 @@ private:
 		Condition* arg2);
 };
 
+class AutomodCondition : public Condition
+{
+public:
+	AutomodCondition(BYTE op,
+		unsigned int automod) : automodID(automod),
+		operation(op) {
+		conditionType = CT_Operand;
+	};
+private:
+	BYTE operation;
+	unsigned int automodID;
+	bool EvaluateInternal(UnitItemInfo* uInfo,
+		Condition* arg1,
+		Condition* arg2);
+	bool EvaluateInternalFromPacket(ItemInfo* info,
+		Condition* arg1,
+		Condition* arg2);
+};
+
 class MagicPrefixCondition : public Condition
 {
 public:


### PR DESCRIPTION
The additional `ITEM_QUALITY_MAGIC` check was added because, unlike prefix/suffix, the automod is always "visible" when unidentified (prefix/suffix always return 0 when unidentified, at least for magic items)