### PR TITLE
Add MAPTIER condition

### DIFF
--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -387,6 +387,14 @@ std::map<std::string, int> code_to_dwtxtfileno = {
 		{"amf", 305},
 };
 
+std::map<std::string, int> maptiers = {
+	{"pvpm", 0},
+	{"t1m", 1},
+	{"t2m", 2},
+	{"t3m", 3},
+	{"t4m", 4},
+};
+
 enum Operation
 {
 	EQUAL,
@@ -1147,6 +1155,7 @@ void Condition::BuildConditions(vector<Condition*>& conditions,
 	else if (key.compare(0, 6, "PREFIX") == 0) { Condition::AddOperand(conditions, new MagicPrefixCondition(operation, value)); }
 	else if (key.compare(0, 6, "SUFFIX") == 0) { Condition::AddOperand(conditions, new MagicSuffixCondition(operation, value)); }
 	else if (key.compare(0, 5, "MAPID") == 0) { Condition::AddOperand(conditions, new MapIdCondition(operation, value)); }
+	else if (key.compare(0, 7, "MAPTIER") == 0) { Condition::AddOperand(conditions, new MapTierCondition(operation, value)); }
 	else if (key.compare(0, 5, "CRAFT") == 0) { Condition::AddOperand(conditions, new QualityCondition(ITEM_QUALITY_CRAFT)); }
 	else if (key.compare(0, 2, "RW") == 0) { Condition::AddOperand(conditions, new FlagsCondition(ITEM_RUNEWORD)); }
 	else if (key.compare(0, 4, "NMAG") == 0) { Condition::AddOperand(conditions, new NonMagicalCondition()); }
@@ -1680,6 +1689,20 @@ bool MapIdCondition::EvaluateInternalFromPacket(ItemInfo* info,
 	auto map_id = **Var_D2CLIENT_MapId();
 
 	return IntegerCompare(map_id, operation, mapId);
+}
+
+bool MapTierCondition::EvaluateInternal(UnitItemInfo* uInfo,
+	Condition* arg1,
+	Condition* arg2)
+{
+	return IntegerCompare(maptiers.at(uInfo->attrs->category), operation, mapTier);
+}
+
+bool MapTierCondition::EvaluateInternalFromPacket(ItemInfo* info,
+	Condition* arg1,
+	Condition* arg2)
+{
+	return IntegerCompare(maptiers.at(info->attrs->category), operation, mapTier);
 }
 
 bool CraftLevelCondition::EvaluateInternal(UnitItemInfo* uInfo,

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -481,6 +481,25 @@ private:
 		Condition* arg2);
 };
 
+class MapTierCondition : public Condition
+{
+public:
+	MapTierCondition(BYTE op,
+		BYTE mtier) : mapTier(mtier),
+		operation(op) {
+		conditionType = CT_Operand;
+	};
+private:
+	BYTE operation;
+	BYTE mapTier;
+	bool EvaluateInternal(UnitItemInfo* uInfo,
+		Condition* arg1,
+		Condition* arg2);
+	bool EvaluateInternalFromPacket(ItemInfo* info,
+		Condition* arg1,
+		Condition* arg2);
+};
+
 class CraftLevelCondition : public Condition
 {
 public:


### PR DESCRIPTION
Allows filtering based on map tier, which should be a _lot_ better than just listing every possible map type. It also means that filter creators won't need to update their filter when maps move to new tiers.

Here's a before and after with Kryszard's filter:

```
//Project Diablo 2 Maps
ItemDisplay[(t10 OR t11 OR t12 OR t13 OR t14 OR t15 OR t16 OR t17 OR t18 OR t19 OR t20 OR t21 OR t22 OR t23 OR t24 OR t25 OR t26 OR t27 OR t28 OR t29 OR t30 OR t31 OR t32 OR t33 OR t34 OR t35 OR t36 OR t37 OR t38 OR t39 OR t40 OR t41 OR t42 OR t43 OR t44 OR t45 OR t46 OR t47 OR t48 OR t49 OR t3a) NMAG]: %WHITE%%NAME%%CONTINUE%
ItemDisplay[(t12 OR t13 OR t16 OR t21 OR t22 OR t23 OR t33)]: %GRAY%[%DARK_GREEN%T1%GRAY%] %NAME% %DARK_GREEN%*%CONTINUE%
ItemDisplay[(t11 OR t14 OR t15 OR t26 OR t34 OR t36)]: %GRAY%[%TAN%T2%GRAY%] %NAME% %TAN%*%CONTINUE%
ItemDisplay[(t24 OR t25 OR t31 OR t32 OR t35 OR t37 OR t38 OR t39 OR t3a)]: %GRAY%[%ORANGE%T3%GRAY%] %NAME% %ORANGE%*%CONTINUE%
ItemDisplay[(t40 OR t41 OR t42 OR t43 OR t44 OR t45 OR t46 OR t47 OR t48 OR t49)]: %GRAY%[%RED%Dungeon%GRAY%] %NAME%%CONTINUE%
ItemDisplay[(t10 OR t11 OR t12 OR t13 OR t14 OR t15 OR t16 OR t17 OR t18 OR t19 OR t20 OR t21 OR t22 OR t23 OR t24 OR t25 OR t26 OR t27 OR t28 OR t29 OR t30 OR t31 OR t32 OR t33 OR t34 OR t35 OR t36 OR t37 OR t38 OR t39 OR t40 OR t41 OR t42 OR t43 OR t44 OR t45 OR t46 OR t47 OR t48 OR t49 OR t3a) (!ID OR NMAG)]: %MAP-7F%%NAME%%CONTINUE%
ItemDisplay[(t10 OR t11 OR t12 OR t13 OR t14 OR t15 OR t16 OR t17 OR t18 OR t19 OR t20 OR t21 OR t22 OR t23 OR t24 OR t25 OR t26 OR t27 OR t28 OR t29 OR t30 OR t31 OR t32 OR t33 OR t34 OR t35 OR t36 OR t37 OR t38 OR t39 OR t3a)]: %NAME%{%TAN%Note%WHITE%: To Modify Maps visit Anya}%CONTINUE%
ItemDisplay[(t10 OR t11 OR t12 OR t13 OR t14 OR t15 OR t16 OR t17 OR t18 OR t19 OR t20 OR t21 OR t22 OR t23 OR t24 OR t25 OR t26 OR t27 OR t28 OR t29 OR t30 OR t31 OR t32 OR t33 OR t34 OR t35 OR t36 OR t37 OR t38 OR t39 OR t3a) MAG]: %NAME%{%WHITE%To Reroll: Cube with 3 %TAN%x %WHITE%Perf %GRAY%O%NL%%NAME%}%CONTINUE%
ItemDisplay[t60 OR t61 OR t62 OR t63 OR t64 OR t65 OR t66 OR t67 OR t68 OR t69]: %NAME%{%GRAY%(without PermaDeath on HC)%NL%You can challenge other Players here%NL%%TAN%Note%WHITE%: PvP Arena}
```

```
ItemDisplay[MAPTIER>0 NMAG]: %WHITE%%NAME%%CONTINUE%
ItemDisplay[MAPTIER=1]: %GRAY%[%DARK_GREEN%T1%GRAY%] %NAME% %DARK_GREEN%*%CONTINUE%
ItemDisplay[MAPTIER=2]: %GRAY%[%TAN%T2%GRAY%] %NAME% %TAN%*%CONTINUE%
ItemDisplay[MAPTIER=3]: %GRAY%[%ORANGE%T3%GRAY%] %NAME% %ORANGE%*%CONTINUE%
ItemDisplay[MAPTIER=4]: %GRAY%[%RED%Dungeon%GRAY%] %NAME%%CONTINUE%
ItemDisplay[MAPTIER>0 (!ID OR NMAG)]: %MAP-7F%%NAME%%CONTINUE%
ItemDisplay[(MAPTIER>0 AND MAPTIER<4)]: %NAME%{%TAN%Note%WHITE%: To Modify Maps visit Anya}%CONTINUE%
ItemDisplay[(MAPTIER>0 AND MAPTIER<4) MAG]: %NAME%{%WHITE%To Reroll: Cube with 3 %TAN%x %WHITE%Perf %GRAY%O%NL%%NAME%}%CONTINUE%
ItemDisplay[MAPTIER=0]: %NAME%{%GRAY%(without PermaDeath on HC)%NL%You can challenge other Players here%NL%%TAN%Note%WHITE%: PvP Arena}
```