### PR TITLE
S6 updates and fixes

### DIFF
--- a/BH/Constants.h
+++ b/BH/Constants.h
@@ -1149,14 +1149,14 @@ enum QuestFlags {
 
 ///////////////////////////////////////////////////
 // Item Attributes (From D2jsp scripting document)
+// https://d2mods.info/forum/viewtopic.php?p=486829#p486829
 ///////////////////////////////////////////////////
 #define ITEM_IDENTIFIED			0x00000010 // Identified
 #define ITEM_SWITCHIN			0x00000040 // Switched in(activated)
 #define ITEM_SWITCHOUT			0x00000080 // Switched out(deactivated)
 #define ITEM_BROKEN				0x00000100 // Broken(0 durability)
 #define ITEM_HASSOCKETS			0x00000800 // Has sockets
-#define ITEM_INSTORE			0x00002000 // In npc store or gamble screen
-#define ITEM_NEW				0x00002000 // In npc store or gamble screen
+#define ITEM_NEW				0x00002000 // Set when an item first drops
 #define ITEM_ISEAR				0x00010000 // Player's ear
 #define ITEM_STARTITEM			0x00020000 // Start item(1 selling/repair value)
 #define ITEM_COMPACTSAVE		0x00200000 

--- a/BH/D2Ptrs.h
+++ b/BH/D2Ptrs.h
@@ -338,6 +338,7 @@ FUNCPTR(D2COMMON, CopyStatList, DWORD __stdcall, (StatList* pStatList, Stat* pSt
 FUNCPTR(D2COMMON, GetBaseStatSigned, int __stdcall, (UnitAny* pUnit, int nStat, int nLayer), -10587, -10216)
 FUNCPTR(D2COMMON, GetUnitStat, DWORD __stdcall, (UnitAny* pUnit, DWORD dwStat, DWORD dwStat2), -10973, -10550)
 FUNCPTR(D2COMMON, GetUnitState, int __stdcall, (UnitAny* pUnit, DWORD dwStateNo), -10494, -10706)
+FUNCPTR(D2COMMON, GetStateStatList, StatList* __stdcall, (UnitAny* pUnit, DWORD dwStateNo), -10871)
 FUNCPTR(D2COMMON, GetStatValueFromStatList, int __stdcall, (StatList* pStatList, int statId, WORD nLayer), -10680)
 
 FUNCPTR(D2COMMON, CheckUnitCollision, DWORD __stdcall, (UnitAny* pUnitA, UnitAny* pUnitB, DWORD dwBitMask), -10839, -10221)

--- a/BH/Drawing/Stats/StatsDisplay.cpp
+++ b/BH/Drawing/Stats/StatsDisplay.cpp
@@ -197,7 +197,6 @@ StatsDisplay::StatsDisplay(std::string name)
 	SetActive(true);
 	SetMinimized(true);
 
-	//BH::config->ReadKey("Character Stats", "VK_8", statsKey);
 	display = this;
 }
 

--- a/BH/MPQInit.cpp
+++ b/BH/MPQInit.cpp
@@ -306,6 +306,7 @@ ItemAttributes ItemAttributeList[] = {
 	{"Flawless Ruby", "glrs", "Gem", 1, 1, 0, 0, 0, 0, 0, 0, 264, 0},
 	{"Perfect Ruby", "gprs", "Gem", 1, 1, 0, 0, 0, 0, 0, 0, 272, 0},
 	{"Flawless Diamond", "glws", "Gem", 1, 1, 0, 0, 0, 0, 0, 0, 72, 0},
+	{"Perfect Diamond", "gpws", "Gem", 1, 1, 0, 0, 0, 0, 0, 0, 80, 0 },
 	{"Flawless Skull", "skls", "Gem", 1, 1, 0, 0, 0, 0, 0, 0, 2056, 0},
 	{"Perfect Skull", "skzs", "Gem", 1, 1, 0, 0, 0, 0, 0, 0, 2064, 0},
 	{"Minor Healing Potion", "hp1", "Health Potion", 1, 1, 0, 1, 0, 0, 0, 0, 0, 0},

--- a/BH/MPQInit.cpp
+++ b/BH/MPQInit.cpp
@@ -3,6 +3,8 @@
 
 unsigned int STAT_MAX;
 unsigned int SKILL_MAX;
+unsigned int PREFIX_MAX;
+unsigned int SUFFIX_MAX;
 bool initialized = false;
 
 std::vector<StatProperties*> AllStatList;
@@ -10,6 +12,8 @@ std::unordered_map<std::string, StatProperties*> StatMap;
 std::vector<CharStats*> CharList;
 std::map<std::string, ItemAttributes*> ItemAttributeMap;
 std::map<std::string, InventoryLayout*> InventoryLayoutMap;
+std::vector<ItemAffixProperties*> AllPrefixList;
+std::vector<ItemAffixProperties*> AllSuffixList;
 
 // These are the standard item attributes (if we can't read the patch mpq file)
 #pragma region DEFAULTS
@@ -1132,6 +1136,8 @@ void InitializeMPQData() {
 				bits->saveAdd = (BYTE)std::strtoul((*d)["Save Add"].c_str(), &end, 10);
 				bits->saveParamBits = (BYTE)std::strtoul((*d)["Save Param Bits"].c_str(), &end, 10);
 				bits->op = (BYTE)std::strtoul((*d)["op"].c_str(), &end, 10);
+				bits->costAdd = (unsigned int)std::strtoul((*d)["Add"].c_str(), &end, 10);
+				bits->costMultiply = (unsigned int)std::strtoul((*d)["Multiply"].c_str(), &end, 10);
 				AllStatList.push_back(bits);
 				StatMap[bits->name] = bits;
 				lastID = (short)id;
@@ -1235,6 +1241,8 @@ void InitializeMPQData() {
 				attrs->flags2 = flags2;
 				attrs->qualityLevel = stoi((*d)["level"], nullptr, 10);
 				attrs->magicLevel = atoi((*d)["magic lvl"].c_str());
+				attrs->maxac = stoi((*d)["maxac"], nullptr, 10);
+				attrs->cost = stoi((*d)["cost"], nullptr, 10);
 				ItemAttributeMap[(*d)["code"]] = attrs;
 			}
 		}
@@ -1321,6 +1329,7 @@ void InitializeMPQData() {
 				attrs->flags2 = flags2;
 				attrs->qualityLevel = stoi((*d)["level"], nullptr, 10);
 				attrs->magicLevel = atoi((*d)["magic lvl"].c_str());
+				attrs->cost = stoi((*d)["cost"], nullptr, 10);
 				ItemAttributeMap[(*d)["code"]] = attrs;
 			}
 		}
@@ -1397,7 +1406,40 @@ void InitializeMPQData() {
 				attrs->flags2 = flags2;
 				attrs->qualityLevel = stoi((*d)["level"], nullptr, 10);
 				attrs->magicLevel = 0;
+				attrs->cost = stoi((*d)["cost"], nullptr, 10);
 				ItemAttributeMap[(*d)["code"]] = attrs;
+			}
+		}
+	}
+
+	if (MpqDataMap.find("magicprefix") != MpqDataMap.end()) {
+		unsigned int id = 1;
+		for (auto d = MpqDataMap["magicprefix"]->data.begin(); d < MpqDataMap["magicprefix"]->data.end(); d++) {
+			if ((*d)["add"].length() >= 0) {
+				ItemAffixProperties* prefix = new ItemAffixProperties();
+				prefix->ID = id;
+				prefix->costAdd = (unsigned int)std::strtoul((*d)["add"].c_str(), &end, 10);
+				prefix->costMultiply = (unsigned int)std::strtoul((*d)["multiply"].c_str(), &end, 10);
+				AllPrefixList.push_back(prefix);
+
+				PREFIX_MAX = id;
+				id += 1;
+			}
+		}
+	}
+
+	if (MpqDataMap.find("magicsuffix") != MpqDataMap.end()) {
+		unsigned int id = 1;
+		for (auto d = MpqDataMap["magicsuffix"]->data.begin(); d < MpqDataMap["magicsuffix"]->data.end(); d++) {
+			if ((*d)["add"].length() >= 0) {
+				ItemAffixProperties* suffix = new ItemAffixProperties();
+				suffix->ID = id;
+				suffix->costAdd = (unsigned int)std::strtoul((*d)["add"].c_str(), &end, 10);
+				suffix->costMultiply = (unsigned int)std::strtoul((*d)["multiply"].c_str(), &end, 10);
+				AllSuffixList.push_back(suffix);
+
+				SUFFIX_MAX = id;
+				id += 1;
 			}
 		}
 	}

--- a/BH/MPQInit.cpp
+++ b/BH/MPQInit.cpp
@@ -293,8 +293,8 @@ ItemAttributes ItemAttributeList[] = {
 	{"Chipped Diamond", "gcw", "Gem", 1, 1, 0, 0, 0, 0, 0, 0, 65, 0},
 	{"Flawed Diamond", "gfw", "Gem", 1, 1, 0, 0, 0, 0, 0, 0, 66, 0},
 	{"Diamond", "gsw", "Gem", 1, 1, 0, 0, 0, 0, 0, 0, 68, 0},
-	{"Flawless Diamond", "glws", "Gem", 1, 1, 0, 0, 0, 0, 0, 0, 72, 0},
-	{"Perfect Diamond", "gpws", "Gem", 1, 1, 0, 0, 0, 0, 0, 0, 80, 0},
+	{"Flawless Diamond", "glw", "Gem", 1, 1, 0, 0, 0, 0, 0, 0, 72, 0},
+	{"Perfect Diamond", "gpw", "Gem", 1, 1, 0, 0, 0, 0, 0, 0, 80, 0},
 	{"Flawless Amethyst", "gzvs", "Gem", 1, 1, 0, 0, 0, 0, 0, 0, 40, 0},
 	{"Perfect Amethyst", "gpvs", "Gem", 1, 1, 0, 0, 0, 0, 0, 0, 48, 0},
 	{"Flawless Topaz", "glys", "Gem", 1, 1, 0, 0, 0, 0, 0, 0, 1032, 0},
@@ -307,7 +307,7 @@ ItemAttributes ItemAttributeList[] = {
 	{"Perfect Ruby", "gprs", "Gem", 1, 1, 0, 0, 0, 0, 0, 0, 272, 0},
 	{"Flawless Diamond", "glws", "Gem", 1, 1, 0, 0, 0, 0, 0, 0, 72, 0},
 	{"Flawless Skull", "skls", "Gem", 1, 1, 0, 0, 0, 0, 0, 0, 2056, 0},
-	{"Perfect Skull", "skz", "Gem", 1, 1, 0, 0, 0, 0, 0, 0, 2064, 0},
+	{"Perfect Skull", "skzs", "Gem", 1, 1, 0, 0, 0, 0, 0, 0, 2064, 0},
 	{"Minor Healing Potion", "hp1", "Health Potion", 1, 1, 0, 1, 0, 0, 0, 0, 0, 0},
 	{"Light Healing Potion", "hp2", "Health Potion", 1, 1, 0, 1, 0, 0, 0, 0, 0, 0},
 	{"Healing Potion", "hp3", "Health Potion", 1, 1, 0, 1, 0, 0, 0, 0, 0, 0},
@@ -1349,10 +1349,10 @@ void InitializeMPQData() {
 				else if (ancestorTypes.find("gem2") != ancestorTypes.end() || ancestorTypes.find("gsm2") != ancestorTypes.end()) {
 					flags2 |= ITEM_GROUP_REGULAR;
 				}
-				else if (ancestorTypes.find("gem3") != ancestorTypes.end() || ancestorTypes.find("gsm3") != ancestorTypes.end()) {
+				else if (ancestorTypes.find("ggm3") != ancestorTypes.end() || ancestorTypes.find("gsm3") != ancestorTypes.end()) {
 					flags2 |= ITEM_GROUP_FLAWLESS;
 				}
-				else if (ancestorTypes.find("gem4") != ancestorTypes.end() || ancestorTypes.find("gsm4") != ancestorTypes.end()) {
+				else if (ancestorTypes.find("ggm4") != ancestorTypes.end() || ancestorTypes.find("gsm4") != ancestorTypes.end()) {
 					flags2 |= ITEM_GROUP_PERFECT;
 				}
 				if (ancestorTypes.find("gema") != ancestorTypes.end() || ancestorTypes.find("ggma") != ancestorTypes.end()) {

--- a/BH/MPQInit.h
+++ b/BH/MPQInit.h
@@ -18,6 +18,8 @@
 
 extern unsigned int STAT_MAX;
 extern unsigned int SKILL_MAX;
+extern unsigned int PREFIX_MAX;
+extern unsigned int SUFFIX_MAX;
 
 // Item attributes from ItemTypes.txt and Weapon/Armor/Misc.txt
 struct ItemAttributes {
@@ -35,6 +37,8 @@ struct ItemAttributes {
 	unsigned int flags2;
 	BYTE qualityLevel;
 	BYTE magicLevel;
+	unsigned int maxac;
+	unsigned int cost;
 };
 
 // Properties from ItemStatCost.txt that we need for parsing incoming 0x9c packets, among other things
@@ -47,6 +51,14 @@ struct StatProperties {
 	BYTE op;
 	BYTE sendParamBits;
 	unsigned short ID;
+	unsigned int costAdd;
+	unsigned int costMultiply;
+};
+
+struct ItemAffixProperties {
+	unsigned int ID;
+	unsigned int costAdd;
+	unsigned int costMultiply;
 };
 
 struct CharStats {
@@ -58,6 +70,8 @@ extern std::unordered_map<std::string, StatProperties*> StatMap;
 extern std::vector<CharStats*> CharList;
 extern std::map<std::string, ItemAttributes*> ItemAttributeMap;
 extern std::map<std::string, InventoryLayout*> InventoryLayoutMap;
+extern std::vector<ItemAffixProperties*> AllPrefixList;
+extern std::vector<ItemAffixProperties*> AllSuffixList;
 
 
 #define STAT_NUMBER(name) (StatMap[name]->ID)

--- a/BH/Modules/GameSettings/GameSettings.cpp
+++ b/BH/Modules/GameSettings/GameSettings.cpp
@@ -31,6 +31,8 @@ void GameSettings::LoadConfig() {
 	BH::config->ReadKey("Show Players Gear", "VK_0", showPlayer);
 	BH::config->ReadKey("Resync Hotkey", "VK_9", resyncKey);
 	BH::config->ReadKey("Character Stats", "VK_8", advStatMenuKey);
+	BH::config->ReadKey("Reload Config", "VK_NUMPAD0", reloadConfig);
+	BH::config->ReadKey("Reload Config Ctrl", "VK_R", reloadConfigCtrl);
 }
 
 void GameSettings::LoadGeneralTab() {
@@ -59,6 +61,11 @@ void GameSettings::LoadGeneralTab() {
 	colored_text = new Drawing::Texthook(generalTab, x, (y), "Advanced Stat Display");
 	colored_text->SetColor(Gold);
 	new Drawing::Keyhook(generalTab, GameSettings::KeyHookOffset, y + 2, &advStatMenuKey, "");
+
+	y += 15;
+	colored_text = new Drawing::Texthook(generalTab, x, (y), "Reload Config");
+	colored_text->SetColor(Gold);
+	new Drawing::Keyhook(generalTab, GameSettings::KeyHookOffset, y + 2, &reloadConfig, "");
 
 	y += 15;
 	new Drawing::Checkhook(generalTab, x, y, &ScreenInfo::Toggles["Experience Meter"].state, "Experience Meter");

--- a/BH/Modules/GameSettings/GameSettings.h
+++ b/BH/Modules/GameSettings/GameSettings.h
@@ -12,6 +12,8 @@ public:
 	static map<std::string, Toggle> Toggles;
 	unsigned int resyncKey;
 	unsigned int advStatMenuKey;
+	unsigned int reloadConfig;
+	unsigned int reloadConfigCtrl;
 
 	GameSettings() : Module("GameSettings") {};
 	~GameSettings() {};

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -2303,6 +2303,23 @@ bool MagicPrefixCondition::EvaluateInternalFromPacket(ItemInfo* info,
 	{
 		return false;
 	}
+	if (operation == GREATER_THAN || operation == LESS_THAN)
+	{
+		return false;
+	}
+
+	// If the vector is empty then we only have 0/1 suffix on the item and the id is in info->suffix
+	if (info->suffixes.size() == 0)
+	{
+		return IntegerCompare(info->suffix, operation, suffixID1, suffixID2);
+	}
+	for (unsigned int i = 0; i < info->suffixes.size(); i++)
+	{
+		if (info->suffixes[i] > 0 ? IntegerCompare(info->suffixes[i], operation, suffixID1, suffixID2) : false)
+		{
+			return true;
+		}
+	}
 
 	return false;
 }
@@ -2345,6 +2362,25 @@ bool MagicSuffixCondition::EvaluateInternalFromPacket(ItemInfo* info,
 	if (info->quality == ITEM_QUALITY_RARE && !(info->identified))
 	{
 		return false;
+	}
+	if (operation == GREATER_THAN || operation == LESS_THAN)
+	{
+		return false;
+	}
+
+	// If the vector is empty then we only have 0/1 prefix on the item and the id is in info->prefix
+	// The ids here also don't match what we get in UnitItemInfo, 
+	// so we need to subtract the total number of suffixes from the expected value(s)
+	if (info->prefixes.size() == 0)
+	{
+		return IntegerCompare(info->prefix, operation, prefixID1 - (int)SUFFIX_MAX, prefixID2 - (int)SUFFIX_MAX);
+	}
+	for (unsigned int i = 0; i < info->prefixes.size(); i++)
+	{
+		if (info->prefixes[i] > 0 ? IntegerCompare(info->prefixes[i], operation, prefixID1 - (int)SUFFIX_MAX, prefixID2 - (int)SUFFIX_MAX) : false)
+		{
+			return true;
+		}
 	}
 
 	return false;

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -2308,14 +2308,16 @@ bool MagicPrefixCondition::EvaluateInternalFromPacket(ItemInfo* info,
 		return false;
 	}
 
-	// If the vector is empty then we only have 0/1 suffix on the item and the id is in info->suffix
-	if (info->suffixes.size() == 0)
+	// If the vector is empty then we only have 0/1 prefix on the item and the id is in info->prefix
+	// The ids here also don't match what we get in UnitItemInfo, 
+	// so we need to subtract the total number of suffixes from the expected value(s)
+	if (info->prefixes.size() == 0)
 	{
-		return IntegerCompare(info->suffix, operation, suffixID1, suffixID2);
+		return IntegerCompare(info->prefix, operation, prefixID1 - (int)SUFFIX_MAX, prefixID2 - (int)SUFFIX_MAX);
 	}
-	for (unsigned int i = 0; i < info->suffixes.size(); i++)
+	for (unsigned int i = 0; i < info->prefixes.size(); i++)
 	{
-		if (info->suffixes[i] > 0 ? IntegerCompare(info->suffixes[i], operation, suffixID1, suffixID2) : false)
+		if (info->prefixes[i] > 0 ? IntegerCompare(info->prefixes[i], operation, prefixID1 - (int)SUFFIX_MAX, prefixID2 - (int)SUFFIX_MAX) : false)
 		{
 			return true;
 		}
@@ -2368,16 +2370,14 @@ bool MagicSuffixCondition::EvaluateInternalFromPacket(ItemInfo* info,
 		return false;
 	}
 
-	// If the vector is empty then we only have 0/1 prefix on the item and the id is in info->prefix
-	// The ids here also don't match what we get in UnitItemInfo, 
-	// so we need to subtract the total number of suffixes from the expected value(s)
-	if (info->prefixes.size() == 0)
+	// If the vector is empty then we only have 0/1 suffix on the item and the id is in info->suffix
+	if (info->suffixes.size() == 0)
 	{
-		return IntegerCompare(info->prefix, operation, prefixID1 - (int)SUFFIX_MAX, prefixID2 - (int)SUFFIX_MAX);
+		return IntegerCompare(info->suffix, operation, suffixID1, suffixID2);
 	}
-	for (unsigned int i = 0; i < info->prefixes.size(); i++)
+	for (unsigned int i = 0; i < info->suffixes.size(); i++)
 	{
-		if (info->prefixes[i] > 0 ? IntegerCompare(info->prefixes[i], operation, prefixID1 - (int)SUFFIX_MAX, prefixID2 - (int)SUFFIX_MAX) : false)
+		if (info->suffixes[i] > 0 ? IntegerCompare(info->suffixes[i], operation, suffixID1, suffixID2) : false)
 		{
 			return true;
 		}

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -2603,7 +2603,7 @@ bool ShopCondition::EvaluateInternalFromPacket(ItemInfo* info,
 	Condition* arg1,
 	Condition* arg2)
 {
-	return IntegerCompare(info->inStore, (BYTE)EQUAL, true);
+	return false;
 }
 
 bool OneHandedCondition::EvaluateInternal(UnitItemInfo* uInfo,

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -448,6 +448,8 @@ enum FilterCondition
 	COND_GEMTYPE,
 	COND_GEM,
 	COND_ED,
+	COND_EDEF,
+	COND_EDAM,
 	COND_DEF,
 	COND_MAXDUR,
 	COND_RES,
@@ -537,6 +539,7 @@ std::map<std::string, FilterCondition> condition_map =
 	{"||", COND_OR},
 	{"ETH", COND_ETH},
 	{"SOCK", COND_SOCK},
+	{"SOCKETS", COND_SOCK},
 	{"SET", COND_SET},
 	{"MAG", COND_MAG},
 	{"RARE", COND_RARE},
@@ -576,6 +579,8 @@ std::map<std::string, FilterCondition> condition_map =
 	{"GEM", COND_GEM},
 	{"GEMLEVEL", COND_GEM},
 	{"ED", COND_ED},
+	{"EDEF", COND_EDEF},
+	{"EDAM", COND_EDAM},
 	{"DEF", COND_DEF},
 	{"MAXDUR", COND_MAXDUR},
 	{"RES", COND_RES},
@@ -1624,6 +1629,12 @@ void Condition::BuildConditions(vector<Condition*>& conditions,
 		break;
 	case COND_ED:
 		Condition::AddOperand(conditions, new EDCondition(operation, value));
+		break;
+	case COND_EDEF:
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_ENHANCEDDEFENSE, 0, operation, value));
+		break;
+	case COND_EDAM:
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_ENHANCEDMAXIMUMDAMAGE, 0, operation, value));
 		break;
 	case COND_DEF:
 		Condition::AddOperand(conditions, new ItemStatCondition(STAT_DEFENSE, 0, operation, value));

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1687,7 +1687,7 @@ void Condition::BuildConditions(vector<Condition*>& conditions,
 		Condition::AddOperand(conditions, new FlagsCondition(ITEM_ETHEREAL));
 		break;
 	case COND_SOCK:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_SOCKETS, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_SOCKETS, 0, operation, value, value2));
 		break;
 	case COND_SET:
 		Condition::AddOperand(conditions, new QualityCondition(ITEM_QUALITY_SET));
@@ -1723,7 +1723,7 @@ void Condition::BuildConditions(vector<Condition*>& conditions,
 		Condition::AddOperand(conditions, new CharacterClassCondition(EQUAL, 6));
 		break;
 	case COND_CRAFTALVL:
-		Condition::AddOperand(conditions, new CraftLevelCondition(operation, value));
+		Condition::AddOperand(conditions, new CraftLevelCondition(operation, value, value2));
 		break;
 	case COND_PREFIX:
 		Condition::AddOperand(conditions, new MagicPrefixCondition(operation, value, value2));
@@ -1732,13 +1732,13 @@ void Condition::BuildConditions(vector<Condition*>& conditions,
 		Condition::AddOperand(conditions, new MagicSuffixCondition(operation, value, value2));
 		break;
 	case COND_AUTOMOD:
-		Condition::AddOperand(conditions, new AutomodCondition(operation, value));
+		Condition::AddOperand(conditions, new AutomodCondition(operation, value, value2));
 		break;
 	case COND_MAPID:
-		Condition::AddOperand(conditions, new MapIdCondition(operation, value));
+		Condition::AddOperand(conditions, new MapIdCondition(operation, value, value2));
 		break;
 	case COND_MAPTIER:
-		Condition::AddOperand(conditions, new MapTierCondition(operation, value));
+		Condition::AddOperand(conditions, new MapTierCondition(operation, value, value2));
 		break;
 	case COND_CRAFT:
 		Condition::AddOperand(conditions, new QualityCondition(ITEM_QUALITY_CRAFT));
@@ -1768,88 +1768,88 @@ void Condition::BuildConditions(vector<Condition*>& conditions,
 		Condition::AddOperand(conditions, new FlagsCondition(ITEM_IDENTIFIED));
 		break;
 	case COND_ILVL:
-		Condition::AddOperand(conditions, new ItemLevelCondition(operation, value));
+		Condition::AddOperand(conditions, new ItemLevelCondition(operation, value, value2));
 		break;
 	case COND_QLVL:
-		Condition::AddOperand(conditions, new QualityLevelCondition(operation, value));
+		Condition::AddOperand(conditions, new QualityLevelCondition(operation, value, value2));
 		break;
 	case COND_ALVL:
-		Condition::AddOperand(conditions, new AffixLevelCondition(operation, value));
+		Condition::AddOperand(conditions, new AffixLevelCondition(operation, value, value2));
 		break;
 	case COND_CLVL:
-		Condition::AddOperand(conditions, new CharStatCondition(STAT_LEVEL, 0, operation, value));
+		Condition::AddOperand(conditions, new CharStatCondition(STAT_LEVEL, 0, operation, value, value2));
 		break;
 	case COND_FILTLVL:
-		Condition::AddOperand(conditions, new FilterLevelCondition(operation, value));
+		Condition::AddOperand(conditions, new FilterLevelCondition(operation, value, value2));
 		break;
 	case COND_DIFF:
-		Condition::AddOperand(conditions, new DifficultyCondition(operation, value));
+		Condition::AddOperand(conditions, new DifficultyCondition(operation, value, value2));
 		break;
 	case COND_RUNE:
-		Condition::AddOperand(conditions, new RuneCondition(operation, value));
+		Condition::AddOperand(conditions, new RuneCondition(operation, value, value2));
 		break;
 	case COND_GOLD:
-		Condition::AddOperand(conditions, new GoldCondition(operation, value));
+		Condition::AddOperand(conditions, new GoldCondition(operation, value, value2));
 		break;
 	case COND_GEMMED:
 		Condition::AddOperand(conditions, new GemmedCondition());
 		break;
 	case COND_GEMTYPE:
-		Condition::AddOperand(conditions, new GemTypeCondition(operation, value));
+		Condition::AddOperand(conditions, new GemTypeCondition(operation, value, value2));
 		break;
 	case COND_GEM:
-		Condition::AddOperand(conditions, new GemLevelCondition(operation, value));
+		Condition::AddOperand(conditions, new GemLevelCondition(operation, value, value2));
 		break;
 	case COND_ED:
-		Condition::AddOperand(conditions, new EDCondition(operation, value));
+		Condition::AddOperand(conditions, new EDCondition(operation, value, value2));
 		break;
 	case COND_EDEF:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_ENHANCEDDEFENSE, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_ENHANCEDDEFENSE, 0, operation, value, value2));
 		break;
 	case COND_EDAM:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_ENHANCEDMAXIMUMDAMAGE, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_ENHANCEDMAXIMUMDAMAGE, 0, operation, value, value2));
 		break;
 	case COND_DEF:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_DEFENSE, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_DEFENSE, 0, operation, value, value2));
 		break;
 	case COND_MAXDUR:
-		Condition::AddOperand(conditions, new DurabilityCondition(operation, value));
+		Condition::AddOperand(conditions, new DurabilityCondition(operation, value, value2));
 		break;
 	case COND_RES:
-		Condition::AddOperand(conditions, new ResistAllCondition(operation, value));
+		Condition::AddOperand(conditions, new ResistAllCondition(operation, value, value2));
 		break;
 	case COND_FRES:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_FIRERESIST, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_FIRERESIST, 0, operation, value, value2));
 		break;
 	case COND_CRES:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_COLDRESIST, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_COLDRESIST, 0, operation, value, value2));
 		break;
 	case COND_LRES:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_LIGHTNINGRESIST, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_LIGHTNINGRESIST, 0, operation, value, value2));
 		break;
 	case COND_PRES:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_POISONRESIST, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_POISONRESIST, 0, operation, value, value2));
 		break;
 	case COND_IAS:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_IAS, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_IAS, 0, operation, value, value2));
 		break;
 	case COND_FCR:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_FASTERCAST, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_FASTERCAST, 0, operation, value, value2));
 		break;
 	case COND_FHR:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_FASTERHITRECOVERY, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_FASTERHITRECOVERY, 0, operation, value, value2));
 		break;
 	case COND_FBR:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_FASTERBLOCK, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_FASTERBLOCK, 0, operation, value, value2));
 		break;
 	case COND_LIFE:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_MAXHP, 0, operation, value * 256));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_MAXHP, 0, operation, value * 256, value2 * 256));
 		break;
 	case COND_MANA:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_MAXMANA, 0, operation, value * 256));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_MAXMANA, 0, operation, value * 256, value2 * 256));
 		break;
 	case COND_QTY:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_AMMOQUANTITY, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_AMMOQUANTITY, 0, operation, value, value2));
 		break;
 	case COND_GOODSK:
 		Condition::AddOperand(conditions, new SkillListCondition(operation, CLASS_SKILLS, value));
@@ -1861,49 +1861,49 @@ void Condition::BuildConditions(vector<Condition*>& conditions,
 		Condition::AddOperand(conditions, new FoolsCondition());
 		break;
 	case COND_LVLREQ:
-		Condition::AddOperand(conditions, new RequiredLevelCondition(operation, value));
+		Condition::AddOperand(conditions, new RequiredLevelCondition(operation, value, value2));
 		break;
 	case COND_ARPER:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_TOHITPERCENT, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_TOHITPERCENT, 0, operation, value, value2));
 		break;
 	case COND_MFIND:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_MAGICFIND, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_MAGICFIND, 0, operation, value, value2));
 		break;
 	case COND_GFIND:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_GOLDFIND, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_GOLDFIND, 0, operation, value, value2));
 		break;
 	case COND_STR:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_STRENGTH, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_STRENGTH, 0, operation, value, value2));
 		break;
 	case COND_DEX:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_DEXTERITY, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_DEXTERITY, 0, operation, value, value2));
 		break;
 	case COND_FRW:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_FASTERRUNWALK, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_FASTERRUNWALK, 0, operation, value, value2));
 		break;
 	case COND_MINDMG:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_MINIMUMDAMAGE, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_MINIMUMDAMAGE, 0, operation, value, value2));
 		break;
 	case COND_MAXDMG:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_MAXIMUMDAMAGE, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_MAXIMUMDAMAGE, 0, operation, value, value2));
 		break;
 	case COND_AR:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_ATTACKRATING, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_ATTACKRATING, 0, operation, value, value2));
 		break;
 	case COND_DTM:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_DAMAGETOMANA, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_DAMAGETOMANA, 0, operation, value, value2));
 		break;
 	case COND_MAEK:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_MANAAFTEREACHKILL, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_MANAAFTEREACHKILL, 0, operation, value, value2));
 		break;
 	case COND_REPLIFE:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_REPLENISHLIFE, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_REPLENISHLIFE, 0, operation, value, value2));
 		break;
 	case COND_REPQUANT:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_REPLENISHESQUANTITY, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_REPLENISHESQUANTITY, 0, operation, value, value2));
 		break;
 	case COND_REPAIR:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_REPAIRSDURABILITY, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_REPAIRSDURABILITY, 0, operation, value, value2));
 		break;
 	case COND_ARMOR:
 		Condition::AddOperand(conditions, new ItemGroupCondition(ITEM_GROUP_ALLARMOR));
@@ -2006,35 +2006,35 @@ void Condition::BuildConditions(vector<Condition*>& conditions,
 		break;
 	case COND_SK:
 		if ((number_ss >> cond_num).fail() || cond_num < 0 || cond_num >(int)SKILL_MAX) { break; }
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_SINGLESKILL, cond_num, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_SINGLESKILL, cond_num, operation, value, value2));
 		break;
 	case COND_OS:
 		if ((number_ss >> cond_num).fail() || cond_num < 0 || cond_num >(int)SKILL_MAX) { break; }
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_NONCLASSSKILL, cond_num, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_NONCLASSSKILL, cond_num, operation, value, value2));
 		break;
 	case COND_CHSK:
 		// skills granted by charges
 		if ((number_ss >> cond_num).fail() || cond_num < 0 || cond_num >(int)SKILL_MAX) { break; }
-		Condition::AddOperand(conditions, new ChargedCondition(operation, cond_num, value));
+		Condition::AddOperand(conditions, new ChargedCondition(operation, cond_num, value, value2));
 		break;
 	case COND_CLSK:
 		if ((number_ss >> cond_num).fail() || cond_num < 0 || cond_num >= CLASS_NA) { break; }
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_CLASSSKILLS, cond_num, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_CLASSSKILLS, cond_num, operation, value, value2));
 		break;
 	case COND_ALLSK:
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_ALLSKILLS, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_ALLSKILLS, 0, operation, value, value2));
 		break;
 	case COND_TABSK:
 		if ((number_ss >> cond_num).fail() || cond_num < 0 || cond_num > SKILLTAB_MAX) { break; }
-		Condition::AddOperand(conditions, new ItemStatCondition(STAT_SKILLTAB, cond_num, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(STAT_SKILLTAB, cond_num, operation, value, value2));
 		break;
 	case COND_STAT:
 		if ((number_ss >> cond_num).fail() || cond_num < 0 || cond_num >(int)STAT_MAX) { break; }
-		Condition::AddOperand(conditions, new ItemStatCondition(cond_num, 0, operation, value));
+		Condition::AddOperand(conditions, new ItemStatCondition(cond_num, 0, operation, value, value2));
 		break;
 	case COND_CHARSTAT:
 		if ((number_ss >> cond_num).fail() || cond_num < 0 || cond_num >(int)STAT_MAX) { break; }
-		Condition::AddOperand(conditions, new CharStatCondition(cond_num, 0, operation, value));
+		Condition::AddOperand(conditions, new CharStatCondition(cond_num, 0, operation, value, value2));
 		break;
 	case COND_MULTI:
 		if (std::regex_search(key, multi_match, multi_reg))
@@ -2043,11 +2043,11 @@ void Condition::BuildConditions(vector<Condition*>& conditions,
 			stat1 = stoi(multi_match[1].str(), nullptr, 10);
 			stat2 = stoi(multi_match[2].str(), nullptr, 10);
 
-			Condition::AddOperand(conditions, new ItemStatCondition(stat1, stat2, operation, value));
+			Condition::AddOperand(conditions, new ItemStatCondition(stat1, stat2, operation, value, value2));
 		}
 		break;
 	case COND_PRICE:
-		Condition::AddOperand(conditions, new ItemPriceCondition(operation, value));
+		Condition::AddOperand(conditions, new ItemPriceCondition(operation, value, value2));
 		break;
 	case COND_ITEMCODE:
 		Condition::AddOperand(conditions, new ItemCodeCondition(key.substr(0, 4).c_str()));
@@ -2099,10 +2099,10 @@ bool Condition::Evaluate(UnitItemInfo* uInfo,
 }
 
 bool FilterLevelCondition::EvaluateInternal(UnitItemInfo* uInfo, Condition* arg1, Condition* arg2) {
-	return IntegerCompare(Item::GetFilterLevel(), operation, filterLevel);
+	return IntegerCompare(Item::GetFilterLevel(), operation, filterLevel, filterLevel2);
 }
 bool FilterLevelCondition::EvaluateInternalFromPacket(ItemInfo* info, Condition* arg1, Condition* arg2) {
-	return IntegerCompare(Item::GetFilterLevel(), operation, filterLevel);
+	return IntegerCompare(Item::GetFilterLevel(), operation, filterLevel, filterLevel2);
 }
 
 bool TrueCondition::EvaluateInternal(UnitItemInfo* uInfo,
@@ -2259,7 +2259,7 @@ bool GemLevelCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	Condition* arg1,
 	Condition* arg2)
 {
-	if (IsGem(uInfo->attrs)) { return IntegerCompare(GetGemLevel(uInfo->attrs), operation, gemLevel); }
+	if (IsGem(uInfo->attrs)) { return IntegerCompare(GetGemLevel(uInfo->attrs), operation, gemLevel, gemLevel2); }
 	return false;
 }
 
@@ -2267,7 +2267,7 @@ bool GemLevelCondition::EvaluateInternalFromPacket(ItemInfo* info,
 	Condition* arg1,
 	Condition* arg2)
 {
-	if (IsGem(info->attrs)) { return IntegerCompare(GetGemLevel(info->attrs), operation, gemLevel); }
+	if (IsGem(info->attrs)) { return IntegerCompare(GetGemLevel(info->attrs), operation, gemLevel, gemLevel2); }
 	return false;
 }
 
@@ -2275,7 +2275,7 @@ bool GemTypeCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	Condition* arg1,
 	Condition* arg2)
 {
-	if (IsGem(uInfo->attrs)) { return IntegerCompare(GetGemType(uInfo->attrs), operation, gemType); }
+	if (IsGem(uInfo->attrs)) { return IntegerCompare(GetGemType(uInfo->attrs), operation, gemType, gemType2); }
 	return false;
 }
 
@@ -2283,7 +2283,7 @@ bool GemTypeCondition::EvaluateInternalFromPacket(ItemInfo* info,
 	Condition* arg1,
 	Condition* arg2)
 {
-	if (IsGem(info->attrs)) { return IntegerCompare(GetGemType(info->attrs), operation, gemType); }
+	if (IsGem(info->attrs)) { return IntegerCompare(GetGemType(info->attrs), operation, gemType, gemType2); }
 	return false;
 }
 
@@ -2291,7 +2291,7 @@ bool RuneCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	Condition* arg1,
 	Condition* arg2)
 {
-	if (IsRune(uInfo->attrs)) { return IntegerCompare(RuneNumberFromItemCode(uInfo->itemCode), operation, runeNumber); }
+	if (IsRune(uInfo->attrs)) { return IntegerCompare(RuneNumberFromItemCode(uInfo->itemCode), operation, runeNumber, runeNumber2); }
 	return false;
 }
 
@@ -2299,7 +2299,7 @@ bool RuneCondition::EvaluateInternalFromPacket(ItemInfo* info,
 	Condition* arg1,
 	Condition* arg2)
 {
-	if (IsRune(info->attrs)) { return IntegerCompare(RuneNumberFromItemCode(info->code), operation, runeNumber); }
+	if (IsRune(info->attrs)) { return IntegerCompare(RuneNumberFromItemCode(info->code), operation, runeNumber, runeNumber2); }
 	return false;
 }
 
@@ -2314,20 +2314,20 @@ bool GoldCondition::EvaluateInternalFromPacket(ItemInfo* info,
 	Condition* arg1,
 	Condition* arg2)
 {
-	if (info->code[0] == 'g' && info->code[1] == 'l' && info->code[2] == 'd') { return IntegerCompare(info->amount, operation, goldAmount); }
+	if (info->code[0] == 'g' && info->code[1] == 'l' && info->code[2] == 'd') { return IntegerCompare(info->amount, operation, goldAmount, goldAmount2); }
 	return false;
 }
 
 bool ItemLevelCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	Condition* arg1,
 	Condition* arg2) {
-	return IntegerCompare(uInfo->item->pItemData->dwItemLevel, operation, itemLevel);
+	return IntegerCompare(uInfo->item->pItemData->dwItemLevel, operation, itemLevel, itemLevel2);
 }
 
 bool ItemLevelCondition::EvaluateInternalFromPacket(ItemInfo* info,
 	Condition* arg1,
 	Condition* arg2) {
-	return IntegerCompare(info->level, operation, itemLevel);
+	return IntegerCompare(info->level, operation, itemLevel, itemLevel2);
 }
 
 bool QualityLevelCondition::EvaluateInternal(UnitItemInfo* uInfo,
@@ -2335,7 +2335,7 @@ bool QualityLevelCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	Condition* arg2)
 {
 	BYTE qlvl = uInfo->attrs->qualityLevel;
-	return IntegerCompare(qlvl, operation, qualityLevel);
+	return IntegerCompare(qlvl, operation, qualityLevel, qualityLevel2);
 }
 
 bool QualityLevelCondition::EvaluateInternalFromPacket(ItemInfo* info,
@@ -2343,7 +2343,7 @@ bool QualityLevelCondition::EvaluateInternalFromPacket(ItemInfo* info,
 	Condition* arg2)
 {
 	int qlvl = info->attrs->qualityLevel;
-	return IntegerCompare(qlvl, operation, qualityLevel);
+	return IntegerCompare(qlvl, operation, qualityLevel, qualityLevel2);
 }
 
 bool AffixLevelCondition::EvaluateInternal(UnitItemInfo* uInfo,
@@ -2352,7 +2352,7 @@ bool AffixLevelCondition::EvaluateInternal(UnitItemInfo* uInfo,
 {
 	BYTE qlvl = uInfo->attrs->qualityLevel;
 	BYTE alvl = GetAffixLevel((BYTE)uInfo->item->pItemData->dwItemLevel, (BYTE)uInfo->attrs->qualityLevel, uInfo->attrs->magicLevel);
-	return IntegerCompare(alvl, operation, affixLevel);
+	return IntegerCompare(alvl, operation, affixLevel, affixLevel2);
 }
 
 bool AffixLevelCondition::EvaluateInternalFromPacket(ItemInfo* info,
@@ -2361,7 +2361,7 @@ bool AffixLevelCondition::EvaluateInternalFromPacket(ItemInfo* info,
 {
 	int  qlvl = info->attrs->qualityLevel;
 	BYTE alvl = GetAffixLevel(info->level, info->attrs->qualityLevel, info->attrs->magicLevel);
-	return IntegerCompare(alvl, operation, affixLevel);
+	return IntegerCompare(alvl, operation, affixLevel, affixLevel2);
 }
 
 bool MapIdCondition::EvaluateInternal(UnitItemInfo* uInfo,
@@ -2370,7 +2370,7 @@ bool MapIdCondition::EvaluateInternal(UnitItemInfo* uInfo,
 {
 	auto map_id = **Var_D2CLIENT_MapId();
 
-	return IntegerCompare(map_id, operation, mapId);
+	return IntegerCompare(map_id, operation, mapId, mapId2);
 }
 
 bool MapIdCondition::EvaluateInternalFromPacket(ItemInfo* info,
@@ -2379,21 +2379,21 @@ bool MapIdCondition::EvaluateInternalFromPacket(ItemInfo* info,
 {
 	auto map_id = **Var_D2CLIENT_MapId();
 
-	return IntegerCompare(map_id, operation, mapId);
+	return IntegerCompare(map_id, operation, mapId, mapId2);
 }
 
 bool MapTierCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	Condition* arg1,
 	Condition* arg2)
 {
-	return IntegerCompare(maptiers.at(uInfo->attrs->category), operation, mapTier);
+	return IntegerCompare(maptiers.at(uInfo->attrs->category), operation, mapTier, mapTier2);
 }
 
 bool MapTierCondition::EvaluateInternalFromPacket(ItemInfo* info,
 	Condition* arg1,
 	Condition* arg2)
 {
-	return IntegerCompare(maptiers.at(info->attrs->category), operation, mapTier);
+	return IntegerCompare(maptiers.at(info->attrs->category), operation, mapTier, mapTier2);
 }
 
 bool CraftLevelCondition::EvaluateInternal(UnitItemInfo* uInfo,
@@ -2413,7 +2413,7 @@ bool CraftLevelCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	//(4) if ilvl < (99 – int(qlvl/2)= then affix level = ilvl - int(qlvl/2) else affix level = ilvl * 2 - 99.
 	auto craft_alvl = craft_ilvl < (99 - qlvl_int / 2) ? craft_ilvl - qlvl_int / 2 : craft_ilvl * 2 - 99;
 
-	return IntegerCompare(craft_alvl, operation, craftLevel);
+	return IntegerCompare(craft_alvl, operation, craftLevel, craftLevel2);
 }
 
 bool CraftLevelCondition::EvaluateInternalFromPacket(ItemInfo* info,
@@ -2433,7 +2433,7 @@ bool CraftLevelCondition::EvaluateInternalFromPacket(ItemInfo* info,
 	//(4) if ilvl < (99 – int(qlvl/2)= then affix level = ilvl - int(qlvl/2) else affix level = ilvl * 2 - 99.
 	auto craft_alvl = craft_ilvl < (99 - qlvl_int / 2) ? craft_ilvl - qlvl_int / 2 : craft_ilvl * 2 - 99;
 
-	return IntegerCompare(craft_alvl, operation, craftLevel);
+	return IntegerCompare(craft_alvl, operation, craftLevel, craftLevel2);
 }
 
 
@@ -2570,7 +2570,7 @@ bool AutomodCondition::EvaluateInternal(UnitItemInfo* uInfo,
 		return false;
 	}
 
-	return IntegerCompare(itemData->wAutoPrefix, operation, automodID);
+	return IntegerCompare(itemData->wAutoPrefix, operation, automodID, automodID2);
 }
 
 bool AutomodCondition::EvaluateInternalFromPacket(ItemInfo* info,
@@ -2604,7 +2604,7 @@ bool RequiredLevelCondition::EvaluateInternal(UnitItemInfo* uInfo,
 {
 	unsigned int rlvl = GetRequiredLevel(uInfo->item);
 
-	return IntegerCompare(rlvl, operation, requiredLevel);
+	return IntegerCompare(rlvl, operation, requiredLevel, requiredLevel2);
 }
 
 bool RequiredLevelCondition::EvaluateInternalFromPacket(ItemInfo* info,
@@ -2640,7 +2640,7 @@ bool EDCondition::EvaluateInternal(UnitItemInfo* uInfo,
 		// Normal %ED will have the same value for STAT_ENHANCEDMAXIMUMDAMAGE and STAT_ENHANCEDMINIMUMDAMAGE
 		stat = STAT_ENHANCEDMAXIMUMDAMAGE;
 	}
-	return IntegerCompare(GetStatFromList(uInfo, stat), operation, targetED);
+	return IntegerCompare(GetStatFromList(uInfo, stat), operation, targetED, targetED2);
 }
 
 bool EDCondition::EvaluateInternalFromPacket(ItemInfo* info,
@@ -2658,7 +2658,7 @@ bool EDCondition::EvaluateInternalFromPacket(ItemInfo* info,
 
 	DWORD value = 0;
 	for (vector<ItemProperty>::iterator prop = info->properties.begin(); prop < info->properties.end(); prop++) { if (prop->stat == stat) { value += prop->value; } }
-	return IntegerCompare(value, operation, targetED);
+	return IntegerCompare(value, operation, targetED, targetED2);
 }
 
 bool DurabilityCondition::EvaluateInternal(UnitItemInfo* uInfo,
@@ -2674,7 +2674,7 @@ bool DurabilityCondition::EvaluateInternal(UnitItemInfo* uInfo,
 		DWORD dwStats = D2COMMON_CopyStatList(pStatList, (Stat*)aStatList, 256);
 		for (UINT i = 0; i < dwStats; i++) { if (aStatList[i].wStatIndex == STAT_ENHANCEDMAXDURABILITY && aStatList[i].wSubIndex == 0) { value += aStatList[i].dwStatValue; } }
 	}
-	return IntegerCompare(value, operation, targetDurability);
+	return IntegerCompare(value, operation, targetDurability, targetDurability2);
 }
 
 bool DurabilityCondition::EvaluateInternalFromPacket(ItemInfo* info,
@@ -2686,7 +2686,7 @@ bool DurabilityCondition::EvaluateInternalFromPacket(ItemInfo* info,
 	{
 		if (prop->stat == STAT_ENHANCEDMAXDURABILITY) { value += prop->value; }
 	}
-	return IntegerCompare(value, operation, targetDurability);
+	return IntegerCompare(value, operation, targetDurability, targetDurability2);
 }
 
 bool ChargedCondition::EvaluateInternal(UnitItemInfo* uInfo,
@@ -2711,7 +2711,7 @@ bool ChargedCondition::EvaluateInternal(UnitItemInfo* uInfo,
 			}
 		}
 	}
-	return IntegerCompare(value, operation, targetLevel);
+	return IntegerCompare(value, operation, targetLevel, targetLevel2);
 }
 
 bool ChargedCondition::EvaluateInternalFromPacket(ItemInfo* info,
@@ -2727,7 +2727,7 @@ bool ChargedCondition::EvaluateInternalFromPacket(ItemInfo* info,
 			//PrintText(1, "Found charged skill. skill=%u level=%u", prop->skill, prop->level);
 		}
 	}
-	return IntegerCompare(num, operation, targetLevel);
+	return IntegerCompare(num, operation, targetLevel, targetLevel2);
 }
 
 bool FoolsCondition::EvaluateInternal(UnitItemInfo* uInfo,
@@ -3033,42 +3033,44 @@ bool SkillListCondition::EvaluateInternalFromPacket(ItemInfo* info,
 bool CharStatCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	Condition* arg1,
 	Condition* arg2) {
-	return IntegerCompare(D2COMMON_GetUnitStat(D2CLIENT_GetPlayerUnit(), stat1, stat2), operation, targetStat);
+	return IntegerCompare(D2COMMON_GetUnitStat(D2CLIENT_GetPlayerUnit(), stat1, stat2), operation, targetStat, targetStat2);
 }
 
 bool CharStatCondition::EvaluateInternalFromPacket(ItemInfo* info,
 	Condition* arg1,
 	Condition* arg2)
 {
-	return IntegerCompare(D2COMMON_GetUnitStat(D2CLIENT_GetPlayerUnit(), stat1, stat2), operation, targetStat);
+	return IntegerCompare(D2COMMON_GetUnitStat(D2CLIENT_GetPlayerUnit(), stat1, stat2), operation, targetStat, targetStat2);
 }
 
 bool DifficultyCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	Condition* arg1,
 	Condition* arg2) {
-	return IntegerCompare(D2CLIENT_GetDifficulty(), operation, targetDiff);
+	return IntegerCompare(D2CLIENT_GetDifficulty(), operation, targetDiff, targetDiff2);
 }
 
 bool DifficultyCondition::EvaluateInternalFromPacket(ItemInfo* info,
 	Condition* arg1,
 	Condition* arg2) {
-	return IntegerCompare(D2CLIENT_GetDifficulty(), operation, targetDiff);
+	return IntegerCompare(D2CLIENT_GetDifficulty(), operation, targetDiff, targetDiff2);
 }
 
 bool ItemStatCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	Condition* arg1,
 	Condition* arg2) {
 	int newTarget = targetStat;
+	int newTarget2 = targetStat2;
 	if (itemStat == STAT_MAXHP || itemStat == STAT_MAXMANA)
 	{
 		newTarget *= 256;
+		newTarget2 *= 256;
 	}
 	// These stat values need to be grabbed differently, otherwise they just return 0
 	else if (itemStat == STAT_ENHANCEDDEFENSE || itemStat == STAT_ENHANCEDMAXIMUMDAMAGE || itemStat == STAT_ENHANCEDMINIMUMDAMAGE)
 	{
-		return IntegerCompare(GetStatFromList(uInfo, itemStat), operation, targetStat);
+		return IntegerCompare(GetStatFromList(uInfo, itemStat), operation, targetStat, targetStat2);
 	}
-	return IntegerCompare(D2COMMON_GetUnitStat(uInfo->item, itemStat, itemStat2), operation, newTarget);
+	return IntegerCompare(D2COMMON_GetUnitStat(uInfo->item, itemStat, itemStat2), operation, newTarget, newTarget2);
 
 }
 
@@ -3080,36 +3082,36 @@ bool ItemStatCondition::EvaluateInternalFromPacket(ItemInfo* info,
 	switch (itemStat)
 	{
 	case STAT_SOCKETS:
-		return IntegerCompare(info->sockets, operation, targetStat);
+		return IntegerCompare(info->sockets, operation, targetStat, targetStat2);
 	case STAT_DEFENSE:
-		return IntegerCompare(GetDefense(info), operation, targetStat);
+		return IntegerCompare(GetDefense(info), operation, targetStat, targetStat2);
 	case STAT_NONCLASSSKILL:
 		for (vector<ItemProperty>::iterator prop = info->properties.begin(); prop < info->properties.end(); prop++)
 		{
 			if (prop->stat == STAT_NONCLASSSKILL && prop->skill == itemStat2) { num += prop->value; }
 		}
-		return IntegerCompare(num, operation, targetStat);
+		return IntegerCompare(num, operation, targetStat, targetStat2);
 	case STAT_SINGLESKILL:
 		for (vector<ItemProperty>::iterator prop = info->properties.begin(); prop < info->properties.end(); prop++)
 		{
 			if (prop->stat == STAT_SINGLESKILL && prop->skill == itemStat2) { num += prop->value; }
 		}
-		return IntegerCompare(num, operation, targetStat);
+		return IntegerCompare(num, operation, targetStat, targetStat2);
 	case STAT_CLASSSKILLS:
 		for (vector<ItemProperty>::iterator prop = info->properties.begin(); prop < info->properties.end(); prop++)
 		{
 			if (prop->stat == STAT_CLASSSKILLS && prop->characterClass == itemStat2) { num += prop->value; }
 		}
-		return IntegerCompare(num, operation, targetStat);
+		return IntegerCompare(num, operation, targetStat, targetStat2);
 	case STAT_SKILLTAB:
 		for (vector<ItemProperty>::iterator prop = info->properties.begin(); prop < info->properties.end(); prop++)
 		{
 			if (prop->stat == STAT_SKILLTAB && (prop->characterClass * 8 + prop->tab) == itemStat2) { num += prop->value; }
 		}
-		return IntegerCompare(num, operation, targetStat);
+		return IntegerCompare(num, operation, targetStat, targetStat2);
 	default:
 		for (vector<ItemProperty>::iterator prop = info->properties.begin(); prop < info->properties.end(); prop++) { if (prop->stat == itemStat) { num += prop->value; } }
-		return IntegerCompare(num, operation, targetStat);
+		return IntegerCompare(num, operation, targetStat, targetStat2);
 	}
 	return false;
 }
@@ -3118,7 +3120,7 @@ bool ItemPriceCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	Condition* arg1,
 	Condition* arg2)
 {
-	return IntegerCompare(D2COMMON_GetItemPrice(D2CLIENT_GetPlayerUnit(), uInfo->item, D2CLIENT_GetDifficulty(), (DWORD)D2CLIENT_GetQuestInfo(), 0x201, 1), operation, targetStat);
+	return IntegerCompare(D2COMMON_GetItemPrice(D2CLIENT_GetPlayerUnit(), uInfo->item, D2CLIENT_GetDifficulty(), (DWORD)D2CLIENT_GetQuestInfo(), 0x201, 1), operation, targetStat, targetStat2);
 }
 
 bool ItemPriceCondition::EvaluateInternalFromPacket(ItemInfo* info,
@@ -3137,10 +3139,10 @@ bool ResistAllCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	int lRes = D2COMMON_GetUnitStat(uInfo->item, STAT_LIGHTNINGRESIST, 0);
 	int cRes = D2COMMON_GetUnitStat(uInfo->item, STAT_COLDRESIST, 0);
 	int pRes = D2COMMON_GetUnitStat(uInfo->item, STAT_POISONRESIST, 0);
-	return (IntegerCompare(fRes, operation, targetStat) &&
-		IntegerCompare(lRes, operation, targetStat) &&
-		IntegerCompare(cRes, operation, targetStat) &&
-		IntegerCompare(pRes, operation, targetStat));
+	return (IntegerCompare(fRes, operation, targetStat, targetStat2) &&
+		IntegerCompare(lRes, operation, targetStat, targetStat2) &&
+		IntegerCompare(cRes, operation, targetStat, targetStat2) &&
+		IntegerCompare(pRes, operation, targetStat, targetStat2));
 }
 
 bool ResistAllCondition::EvaluateInternalFromPacket(ItemInfo* info,
@@ -3155,10 +3157,10 @@ bool ResistAllCondition::EvaluateInternalFromPacket(ItemInfo* info,
 		else if (prop->stat == STAT_COLDRESIST) { cRes += prop->value; }
 		else if (prop->stat == STAT_POISONRESIST) { pRes += prop->value; }
 	}
-	return (IntegerCompare(fRes, operation, targetStat) &&
-		IntegerCompare(lRes, operation, targetStat) &&
-		IntegerCompare(cRes, operation, targetStat) &&
-		IntegerCompare(pRes, operation, targetStat));
+	return (IntegerCompare(fRes, operation, targetStat, targetStat2) &&
+		IntegerCompare(lRes, operation, targetStat, targetStat2) &&
+		IntegerCompare(cRes, operation, targetStat, targetStat2) &&
+		IntegerCompare(pRes, operation, targetStat, targetStat2));
 }
 
 void AddCondition::Init()

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -687,6 +687,37 @@ std::map<std::string, FilterCondition> condition_map =
 
 };
 
+std::map<std::string, int> stat_id_map =
+{
+	{"EDEF", STAT_ENHANCEDDEFENSE},
+	{"EDAM", STAT_ENHANCEDMAXIMUMDAMAGE},
+	{"DEF", STAT_DEFENSE},
+	{"FRES", STAT_FIRERESIST},
+	{"CRES", STAT_COLDRESIST},
+	{"LRES", STAT_LIGHTNINGRESIST},
+	{"PRES", STAT_POISONRESIST},
+	{"IAS", STAT_IAS},
+	{"FCR", STAT_FASTERCAST},
+	{"FHR", STAT_FASTERHITRECOVERY},
+	{"FBR", STAT_FASTERBLOCK},
+	{"LIFE", STAT_MAXHP},
+	{"MANA", STAT_MAXMANA},
+	{"ARPER", STAT_TOHITPERCENT},
+	{"MFIND", STAT_MAGICFIND},
+	{"GFIND", STAT_GOLDFIND},
+	{"STR", STAT_STRENGTH},
+	{"DEX", STAT_DEXTERITY},
+	{"FRW", STAT_FASTERRUNWALK},
+	{"MINDMG", STAT_MINIMUMDAMAGE},
+	{"MAXDMG", STAT_MAXIMUMDAMAGE},
+	{"AR", STAT_ATTACKRATING},
+	{"DTM", STAT_DAMAGETOMANA},
+	{"MAEK", STAT_MANAAFTEREACHKILL},
+	{"REPLIFE", STAT_REPLENISHLIFE},
+	{"REPQUANT", STAT_REPLENISHESQUANTITY},
+	{"REPAIR", STAT_REPAIRSDURABILITY},
+};
+
 SkillReplace skills[] = {
 	COMBO_STATS
 };
@@ -959,11 +990,20 @@ void SubstituteNameVariables(UnitItemInfo* uInfo,
 			else { name.replace(name.find("%" + replacements[n].key + "%"), replacements[n].key.length() + 2, replacements[n].value); }
 		}
 	}
-
-	// stat replacements
-	if (name.find("%STAT-") != string::npos)
+	// Replace named stat output strings with their STAT# counterpart
+	map<string, int>::iterator it;
+	for (it = stat_id_map.begin(); it != stat_id_map.end(); it++)
 	{
-		std::regex  stat_reg("%STAT-([0-9]{1,4})%", std::regex_constants::ECMAScript);
+		while (name.find("%" + it->first + "%") != string::npos)
+		{
+			name.replace(name.find("%" + it->first + "%"), it->first.length() + 2, "%STAT" + std::to_string(it->second) + "%");
+		}
+	}
+
+	// stat & skill replacements
+	if (name.find("%STAT") != string::npos)
+	{
+		std::regex  stat_reg("%STAT([0-9]{1,4})%", std::regex_constants::ECMAScript);
 		std::smatch stat_match;
 
 		while (std::regex_search(name, stat_match, stat_reg))
@@ -983,6 +1023,127 @@ void SubstituteNameVariables(UnitItemInfo* uInfo,
 				{
 					value = GetStatFromList(uInfo, stat);
 				}
+				sprintf_s(statVal, "%d", value);
+			}
+			name.replace(
+				stat_match.prefix().length(),
+				stat_match[0].length(),
+				statVal);
+		}
+	}
+	else if (name.find("%SK") != string::npos)
+	{
+		std::regex  stat_reg("%SK([0-9]{1,4})%", std::regex_constants::ECMAScript);
+		std::smatch stat_match;
+
+		while (std::regex_search(name, stat_match, stat_reg))
+		{
+			int stat2 = stoi(stat_match[1].str(), nullptr, 10);
+			statVal[0] = '\0';
+			if (stat2 <= (int)SKILL_MAX)
+			{
+				auto value = D2COMMON_GetUnitStat(item, STAT_SINGLESKILL, stat2);
+				sprintf_s(statVal, "%d", value);
+			}
+			name.replace(
+				stat_match.prefix().length(),
+				stat_match[0].length(),
+				statVal);
+		}
+	}
+	else if (name.find("%OS") != string::npos)
+	{
+		std::regex  stat_reg("%OS([0-9]{1,4})%", std::regex_constants::ECMAScript);
+		std::smatch stat_match;
+
+		while (std::regex_search(name, stat_match, stat_reg))
+		{
+			int stat2 = stoi(stat_match[1].str(), nullptr, 10);
+			statVal[0] = '\0';
+			if (stat2 <= (int)SKILL_MAX)
+			{
+				auto value = D2COMMON_GetUnitStat(item, STAT_NONCLASSSKILL, stat2);
+				sprintf_s(statVal, "%d", value);
+			}
+			name.replace(
+				stat_match.prefix().length(),
+				stat_match[0].length(),
+				statVal);
+		}
+	}
+	else if (name.find("%CLSK") != string::npos)
+	{
+		std::regex  stat_reg("%CLSK([0-9]{1,4})%", std::regex_constants::ECMAScript);
+		std::smatch stat_match;
+
+		while (std::regex_search(name, stat_match, stat_reg))
+		{
+			int stat2 = stoi(stat_match[1].str(), nullptr, 10);
+			statVal[0] = '\0';
+			if (stat2 <= (int)SKILL_MAX)
+			{
+				auto value = D2COMMON_GetUnitStat(item, STAT_CLASSSKILLS, stat2);
+				sprintf_s(statVal, "%d", value);
+			}
+			name.replace(
+				stat_match.prefix().length(),
+				stat_match[0].length(),
+				statVal);
+		}
+	}
+	else if (name.find("%TABSK") != string::npos)
+	{
+		std::regex  stat_reg("%TABSK([0-9]{1,4})%", std::regex_constants::ECMAScript);
+		std::smatch stat_match;
+
+		while (std::regex_search(name, stat_match, stat_reg))
+		{
+			int stat2 = stoi(stat_match[1].str(), nullptr, 10);
+			statVal[0] = '\0';
+			if (stat2 <= (int)SKILL_MAX)
+			{
+				auto value = D2COMMON_GetUnitStat(item, STAT_SKILLTAB, stat2);
+				sprintf_s(statVal, "%d", value);
+			}
+			name.replace(
+				stat_match.prefix().length(),
+				stat_match[0].length(),
+				statVal);
+		}
+	}
+	else if (name.find("%MULTI") != string::npos)
+	{
+		std::regex  stat_reg("%MULTI([0-9]{1,4}),([0-9]{1,4})%", std::regex_constants::ECMAScript);
+		std::smatch stat_match;
+
+		while (std::regex_search(name, stat_match, stat_reg))
+		{
+			int stat = stoi(stat_match[1].str(), nullptr, 10);
+			int stat2 = stoi(stat_match[2].str(), nullptr, 10);
+			statVal[0] = '\0';
+			if (stat <= (int)STAT_MAX)
+			{
+				auto value = D2COMMON_GetUnitStat(item, stat, stat2);
+				sprintf_s(statVal, "%d", value);
+			}
+			name.replace(
+				stat_match.prefix().length(),
+				stat_match[0].length(),
+				statVal);
+		}
+	}
+	else if (name.find("%CHARSTAT") != string::npos)
+	{
+		std::regex  stat_reg("%CHARSTAT([0-9]{1,4})%", std::regex_constants::ECMAScript);
+		std::smatch stat_match;
+
+		while (std::regex_search(name, stat_match, stat_reg))
+		{
+			int stat = stoi(stat_match[1].str(), nullptr, 10);
+			statVal[0] = '\0';
+			if (stat <= (int)STAT_MAX)
+			{
+				auto value = D2COMMON_GetUnitStat(D2CLIENT_GetPlayerUnit(), stat, 0);
 				sprintf_s(statVal, "%d", value);
 			}
 			name.replace(

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1076,10 +1076,10 @@ unsigned int GetItemCodeIndex(char codeChar)
 	return codeChar - (codeChar < 90 ? 48 : 87);
 }
 
-bool IntegerCompare(unsigned int Lvalue,
+bool IntegerCompare(int Lvalue,
 	BYTE         operation,
-	unsigned int Rvalue,
-	unsigned int Bvalue = 0)
+	int Rvalue,
+	int Bvalue = 0)
 {
 	switch (operation)
 	{

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -641,7 +641,7 @@ std::map<std::string, FilterCondition> condition_map =
 	{"WAND", COND_WAND},
 	{"SCEPTER", COND_SCEPTER},
 	{"EQ1", COND_HELM},
-	{"EQ2", COND_ARMOR},
+	{"EQ2", COND_CHEST},
 	{"EQ3", COND_SHIELD},
 	{"EQ4", COND_GLOVES},
 	{"EQ5", COND_BOOTS},

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -2566,7 +2566,7 @@ bool EquippedCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	{
 		if (uInfo->item->pItemData->pOwnerInventory->dwOwnerId == D2CLIENT_GetPlayerUnit()->dwUnitId)
 		{
-			if (uInfo->item->pItemData->BodyLocation > 0)
+			if (uInfo->item->pItemData->BodyLocation > 0 && uInfo->item->pItemData->ItemLocation == STORAGE_NULL)
 			{
 				is_equipped = true;
 			}
@@ -2580,7 +2580,7 @@ bool EquippedCondition::EvaluateInternalFromPacket(ItemInfo* info,
 	Condition* arg1,
 	Condition* arg2)
 {
-	return IntegerCompare(info->equipped, (BYTE)EQUAL, true);
+	return false;
 }
 
 bool ShopCondition::EvaluateInternal(UnitItemInfo* uInfo,

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -2609,126 +2609,142 @@ bool OneHandedCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	Condition* arg1,
 	Condition* arg2)
 {
-	int weapon_number = code_to_dwtxtfileno[uInfo->itemCode];
-	WeaponType weapon_type = (weapon_number == 0)
-		? (uInfo->itemCode == "hax") ? WeaponType::kAxe : WeaponType::kUnknown
-		: Drawing::StatsDisplay::GetCurrentWeaponType(weapon_number);
-	bool is_onehanded = false;
-
-	if (weapon_type == WeaponType::kAxe ||
-		weapon_type == WeaponType::kWand ||
-		weapon_type == WeaponType::kClub ||
-		weapon_type == WeaponType::kScepter ||
-		weapon_type == WeaponType::kMace ||
-		weapon_type == WeaponType::kHammer ||
-		weapon_type == WeaponType::kSword ||
-		weapon_type == WeaponType::kKnife ||
-		weapon_type == WeaponType::kThrowing ||
-		weapon_type == WeaponType::kJavelin ||
-		weapon_type == WeaponType::kThrowingPot ||
-		weapon_type == WeaponType::kClaw1 ||
-		weapon_type == WeaponType::kClaw2 ||
-		weapon_type == WeaponType::kOrb ||
-		weapon_type == WeaponType::kAmaJav
-
-		)
+	if (code_to_dwtxtfileno.find(uInfo->itemCode) != code_to_dwtxtfileno.end())
 	{
-		is_onehanded = true;
-	}
+		int weapon_number = code_to_dwtxtfileno[uInfo->itemCode];
+		WeaponType weapon_type = Drawing::StatsDisplay::GetCurrentWeaponType(weapon_number);
+		bool is_onehanded = false;
 
-	return IntegerCompare(is_onehanded, (BYTE)EQUAL, 1);
+		if (weapon_type == WeaponType::kAxe ||
+			weapon_type == WeaponType::kWand ||
+			weapon_type == WeaponType::kClub ||
+			weapon_type == WeaponType::kScepter ||
+			weapon_type == WeaponType::kMace ||
+			weapon_type == WeaponType::kHammer ||
+			weapon_type == WeaponType::kSword ||
+			weapon_type == WeaponType::kKnife ||
+			weapon_type == WeaponType::kThrowing ||
+			weapon_type == WeaponType::kJavelin ||
+			weapon_type == WeaponType::kThrowingPot ||
+			weapon_type == WeaponType::kClaw1 ||
+			weapon_type == WeaponType::kClaw2 ||
+			weapon_type == WeaponType::kOrb ||
+			weapon_type == WeaponType::kAmaJav
+			)
+		{
+			is_onehanded = true;
+		}
+
+		return IntegerCompare(is_onehanded, (BYTE)EQUAL, 1);
+	}
+	else
+	{
+		return false;
+	}
 }
 
 bool OneHandedCondition::EvaluateInternalFromPacket(ItemInfo* info,
 	Condition* arg1,
 	Condition* arg2)
 {
-	int weapon_number = code_to_dwtxtfileno[info->code];
-	WeaponType weapon_type = (weapon_number == 0)
-		? (info->code == "hax") ? WeaponType::kAxe : WeaponType::kUnknown
-		: Drawing::StatsDisplay::GetCurrentWeaponType(weapon_number);
-	bool is_onehanded = false;
-
-	if (weapon_type == WeaponType::kAxe ||
-		weapon_type == WeaponType::kWand ||
-		weapon_type == WeaponType::kClub ||
-		weapon_type == WeaponType::kScepter ||
-		weapon_type == WeaponType::kMace ||
-		weapon_type == WeaponType::kHammer ||
-		weapon_type == WeaponType::kSword ||
-		weapon_type == WeaponType::kKnife ||
-		weapon_type == WeaponType::kThrowing ||
-		weapon_type == WeaponType::kJavelin ||
-		weapon_type == WeaponType::kThrowingPot ||
-		weapon_type == WeaponType::kClaw1 ||
-		weapon_type == WeaponType::kClaw2 ||
-		weapon_type == WeaponType::kOrb ||
-		weapon_type == WeaponType::kAmaJav
-
-		)
+	if (code_to_dwtxtfileno.find(info->code) != code_to_dwtxtfileno.end())
 	{
-		is_onehanded = true;
-	}
+		int weapon_number = code_to_dwtxtfileno[info->code];
+		WeaponType weapon_type = Drawing::StatsDisplay::GetCurrentWeaponType(weapon_number);
+		bool is_onehanded = false;
 
-	return IntegerCompare(is_onehanded, (BYTE)EQUAL, 1);
+		if (weapon_type == WeaponType::kAxe ||
+			weapon_type == WeaponType::kWand ||
+			weapon_type == WeaponType::kClub ||
+			weapon_type == WeaponType::kScepter ||
+			weapon_type == WeaponType::kMace ||
+			weapon_type == WeaponType::kHammer ||
+			weapon_type == WeaponType::kSword ||
+			weapon_type == WeaponType::kKnife ||
+			weapon_type == WeaponType::kThrowing ||
+			weapon_type == WeaponType::kJavelin ||
+			weapon_type == WeaponType::kThrowingPot ||
+			weapon_type == WeaponType::kClaw1 ||
+			weapon_type == WeaponType::kClaw2 ||
+			weapon_type == WeaponType::kOrb ||
+			weapon_type == WeaponType::kAmaJav
+			)
+		{
+			is_onehanded = true;
+		}
+
+		return IntegerCompare(is_onehanded, (BYTE)EQUAL, 1);
+	}
+	else
+	{
+		return false;
+	}
 }
 
 bool TwoHandedCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	Condition* arg1,
 	Condition* arg2)
 {
-	int weapon_number = code_to_dwtxtfileno[uInfo->itemCode];
-	WeaponType weapon_type = (weapon_number == 0)
-		? (uInfo->itemCode == "hax") ? WeaponType::kAxe : WeaponType::kUnknown
-		: Drawing::StatsDisplay::GetCurrentWeaponType(weapon_number);
-	bool is_twohanded = false;
-
-	if (weapon_type == WeaponType::kAxe2H ||
-		weapon_type == WeaponType::kHammer2H ||
-		weapon_type == WeaponType::kSword2H ||
-		weapon_type == WeaponType::kSpear ||
-		weapon_type == WeaponType::kPole ||
-		weapon_type == WeaponType::kStaff ||
-		weapon_type == WeaponType::kBow ||
-		weapon_type == WeaponType::kCrossbow ||
-		weapon_type == WeaponType::kAmaBow ||
-		weapon_type == WeaponType::kAmaSpear
-
-		)
+	if (code_to_dwtxtfileno.find(uInfo->itemCode) != code_to_dwtxtfileno.end())
 	{
-		is_twohanded = true;
-	}
+		int weapon_number = code_to_dwtxtfileno[uInfo->itemCode];
+		WeaponType weapon_type = Drawing::StatsDisplay::GetCurrentWeaponType(weapon_number);
+		bool is_twohanded = false;
 
-	return IntegerCompare(is_twohanded, (BYTE)EQUAL, true);
+		if (weapon_type == WeaponType::kAxe2H ||
+			weapon_type == WeaponType::kHammer2H ||
+			weapon_type == WeaponType::kSword2H ||
+			weapon_type == WeaponType::kSpear ||
+			weapon_type == WeaponType::kPole ||
+			weapon_type == WeaponType::kStaff ||
+			weapon_type == WeaponType::kBow ||
+			weapon_type == WeaponType::kCrossbow ||
+			weapon_type == WeaponType::kAmaBow ||
+			weapon_type == WeaponType::kAmaSpear
+			)
+		{
+			is_twohanded = true;
+		}
+
+		return IntegerCompare(is_twohanded, (BYTE)EQUAL, true);
+	}
+	else
+	{
+		return false;
+	}
 }
 
 bool TwoHandedCondition::EvaluateInternalFromPacket(ItemInfo* info,
 	Condition* arg1,
 	Condition* arg2)
 {
-	int weapon_number = code_to_dwtxtfileno[info->code];
-	WeaponType weapon_type = (weapon_number == 0)
-		? (info->code == "hax") ? WeaponType::kAxe : WeaponType::kUnknown
-		: Drawing::StatsDisplay::GetCurrentWeaponType(weapon_number);
-	bool is_twohanded = false;
-
-	if (weapon_type == WeaponType::kAxe2H ||
-		weapon_type == WeaponType::kHammer2H ||
-		weapon_type == WeaponType::kSword2H ||
-		weapon_type == WeaponType::kSpear ||
-		weapon_type == WeaponType::kPole ||
-		weapon_type == WeaponType::kStaff ||
-		weapon_type == WeaponType::kBow ||
-		weapon_type == WeaponType::kCrossbow ||
-		weapon_type == WeaponType::kAmaBow ||
-		weapon_type == WeaponType::kAmaSpear
-
-		)
+	if (code_to_dwtxtfileno.find(info->code) != code_to_dwtxtfileno.end())
 	{
-		is_twohanded = true;
-	}
+		int weapon_number = code_to_dwtxtfileno[info->code];
+		WeaponType weapon_type = Drawing::StatsDisplay::GetCurrentWeaponType(weapon_number);
+		bool is_twohanded = false;
 
-	return IntegerCompare(is_twohanded, (BYTE)EQUAL, true);
+		if (weapon_type == WeaponType::kAxe2H ||
+			weapon_type == WeaponType::kHammer2H ||
+			weapon_type == WeaponType::kSword2H ||
+			weapon_type == WeaponType::kSpear ||
+			weapon_type == WeaponType::kPole ||
+			weapon_type == WeaponType::kStaff ||
+			weapon_type == WeaponType::kBow ||
+			weapon_type == WeaponType::kCrossbow ||
+			weapon_type == WeaponType::kAmaBow ||
+			weapon_type == WeaponType::kAmaSpear
+			)
+		{
+			is_twohanded = true;
+		}
+
+		return IntegerCompare(is_twohanded, (BYTE)EQUAL, true);
+	}
+	else
+	{
+		return false;
+	}
 }
 
 bool GemmedCondition::EvaluateInternal(UnitItemInfo* uInfo,

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -574,6 +574,7 @@ std::map<std::string, FilterCondition> condition_map =
 	{"GEMMED", COND_GEMMED},
 	{"GEMTYPE", COND_GEMTYPE},
 	{"GEM", COND_GEM},
+	{"GEMLEVEL", COND_GEM},
 	{"ED", COND_ED},
 	{"DEF", COND_DEF},
 	{"MAXDUR", COND_MAXDUR},

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -907,7 +907,7 @@ void SubstituteNameVariables(UnitItemInfo* uInfo,
 {
 	char origName[512], sockets[4], code[5], ilvl[4], alvl[4], craftalvl[4], runename[16] = "", runenum[4] = "0";
 	char gemtype[16] = "", gemlevel[16] = "", sellValue[16] = "", statVal[16] = "", qty[4] = "";
-	char lvlreq[4], wpnspd[4], rangeadder[4];
+	char lvlreq[4], wpnspd[4], rangeadder[4], allres[4];
 
 	UnitAny* item = uInfo->item;
 	ItemsTxt* txt = D2COMMON_GetItemText(item->dwTxtFileNo);
@@ -924,6 +924,17 @@ void SubstituteNameVariables(UnitItemInfo* uInfo,
 		(BYTE)uInfo->attrs->qualityLevel,
 		uInfo->attrs->magicLevel);
 	auto clvl_int = D2COMMON_GetUnitStat(D2CLIENT_GetPlayerUnit(), STAT_LEVEL, 0);
+
+	int fRes = D2COMMON_GetUnitStat(item, STAT_FIRERESIST, 0);
+	int lRes = D2COMMON_GetUnitStat(item, STAT_LIGHTNINGRESIST, 0);
+	int cRes = D2COMMON_GetUnitStat(item, STAT_COLDRESIST, 0);
+	int pRes = D2COMMON_GetUnitStat(item, STAT_POISONRESIST, 0);
+	int minres = 0;
+	if (fRes && lRes && cRes && pRes)
+	{
+		minres = min(min(fRes, lRes), min(cRes, pRes));
+	}
+	sprintf_s(allres, "%d", minres);
 
 	sprintf_s(sockets, "%d", D2COMMON_GetUnitStat(item, STAT_SOCKETS, 0));
 	sprintf_s(ilvl, "%d", item->pItemData->dwItemLevel);
@@ -978,6 +989,7 @@ void SubstituteNameVariables(UnitItemInfo* uInfo,
 		{ "NL", "\n" },
 		{ "PRICE", sellValue },
 		{ "QTY", qty },
+		{ "RES", allres},
 		COLOR_REPLACEMENTS
 	};
 	int nColorCodesSize = 0;

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -91,21 +91,21 @@ struct ItemInfo
 	BYTE                       sockets;
 	bool                       equipped;
 	bool                       inSocket;
-	bool                       identified;
-	bool                       switchedIn;
-	bool                       switchedOut;
-	bool                       broken;
+	bool                       identified;		// ITEM_IDENTIFIED
+	bool                       switchedIn;		// ITEM_SWITCHIN
+	bool                       switchedOut;		// ITEM_SWITCHOUT
+	bool                       broken;			// ITEM_BROKEN
 	bool                       potion;
-	bool                       hasSockets;
-	bool                       inStore;
+	bool                       hasSockets;		// ITEM_HASSOCKETS
+	bool                       inStore;			// ITEM_NEW
 	bool                       notInSocket;
-	bool                       ear;
-	bool                       startItem;
-	bool                       simpleItem;
-	bool                       ethereal;
-	bool                       personalized;
+	bool                       ear;				// ITEM_ISEAR
+	bool                       startItem;		// ITEM_STARTITEM
+	bool                       simpleItem;		// ITEM_COMPACTSAVE
+	bool                       ethereal;		// ITEM_ETHEREAL
+	bool                       personalized;	// ITEM_PERSONALIZED
 	bool                       gambling;
-	bool                       runeword;
+	bool                       runeword;		// ITEM_RUNEWORD
 	bool                       ground;
 	bool                       unspecifiedDirectory;
 	bool                       isGold;

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -1139,3 +1139,4 @@ BYTE GetAffixLevel(BYTE ilvl,
 	BYTE mlvl);
 BYTE GetRequiredLevel(UnitAny* item);
 BYTE RuneNumberFromItemCode(char* code);
+int GetStatFromList(UnitItemInfo* uInfo, int itemStat);

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -1120,9 +1120,9 @@ int    ParseMapColor(Action* act,
 void HandleUnknownItemCode(char* code,
 	char* tag);
 BYTE        GetOperation(string* op);
-inline bool IntegerCompare(unsigned int Lvalue,
+inline bool IntegerCompare(int Lvalue,
 	int          operation,
-	unsigned int Rvalue);
+	int Rvalue);
 void GetItemName(UnitItemInfo* uInfo,
 	string& name);
 void SubstituteNameVariables(UnitItemInfo* uInfo,

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -333,13 +333,16 @@ class GemLevelCondition : public Condition
 {
 public:
 	GemLevelCondition(BYTE op,
-		BYTE gem) : gemLevel(gem),
+		BYTE gem,
+		BYTE gem2) : gemLevel(gem),
+		gemLevel2(gem2),
 		operation(op) {
 		conditionType = CT_Operand;
 	};
 private:
 	BYTE operation;
 	BYTE gemLevel;
+	BYTE gemLevel2;
 	bool EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);
@@ -352,13 +355,16 @@ class GemTypeCondition : public Condition
 {
 public:
 	GemTypeCondition(BYTE op,
-		BYTE gType) : gemType(gType),
+		BYTE gType,
+		BYTE gType2) : gemType(gType),
+		gemType2(gType2),
 		operation(op) {
 		conditionType = CT_Operand;
 	};
 private:
 	BYTE operation;
 	BYTE gemType;
+	BYTE gemType2;
 	bool EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);
@@ -371,13 +377,16 @@ class RuneCondition : public Condition
 {
 public:
 	RuneCondition(BYTE op,
-		BYTE rune) : runeNumber(rune),
+		BYTE rune,
+		BYTE rune2) : runeNumber(rune),
+		runeNumber2(rune2),
 		operation(op) {
 		conditionType = CT_Operand;
 	};
 private:
 	BYTE operation;
 	BYTE runeNumber;
+	BYTE runeNumber2;
 	bool EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);
@@ -389,14 +398,17 @@ private:
 class GoldCondition : public Condition
 {
 public:
-	GoldCondition(BYTE         op,
-		unsigned int amt) : goldAmount(amt),
+	GoldCondition(BYTE op,
+		unsigned int amt,
+		unsigned int amt2) : goldAmount(amt),
+		goldAmount2(amt2),
 		operation(op) {
 		conditionType = CT_Operand;
 	};
 private:
 	BYTE         operation;
 	unsigned int goldAmount;
+	unsigned int goldAmount2;
 	bool         EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);
@@ -409,13 +421,16 @@ class ItemLevelCondition : public Condition
 {
 public:
 	ItemLevelCondition(BYTE op,
-		BYTE ilvl) : itemLevel(ilvl),
+		BYTE ilvl,
+		BYTE ilvl2) : itemLevel(ilvl),
+		itemLevel2(ilvl2),
 		operation(op) {
 		conditionType = CT_Operand;
 	};
 private:
 	BYTE operation;
 	BYTE itemLevel;
+	BYTE itemLevel2;
 	bool EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);
@@ -428,13 +443,16 @@ class QualityLevelCondition : public Condition
 {
 public:
 	QualityLevelCondition(BYTE op,
-		BYTE qlvl) : qualityLevel(qlvl),
+		BYTE qlvl,
+		BYTE qlvl2) : qualityLevel(qlvl),
+		qualityLevel2(qlvl2),
 		operation(op) {
 		conditionType = CT_Operand;
 	};
 private:
 	BYTE operation;
 	BYTE qualityLevel;
+	BYTE qualityLevel2;
 	bool EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);
@@ -447,13 +465,16 @@ class AffixLevelCondition : public Condition
 {
 public:
 	AffixLevelCondition(BYTE op,
-		BYTE alvl) : affixLevel(alvl),
+		BYTE alvl,
+		BYTE alvl2) : affixLevel(alvl),
+		affixLevel2(alvl2),
 		operation(op) {
 		conditionType = CT_Operand;
 	};
 private:
 	BYTE operation;
 	BYTE affixLevel;
+	BYTE affixLevel2;
 	bool EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);
@@ -466,13 +487,16 @@ class MapIdCondition : public Condition
 {
 public:
 	MapIdCondition(BYTE op,
-		BYTE mid) : mapId(mid),
+		BYTE mid,
+		BYTE mid2) : mapId(mid),
+		mapId2(mid2),
 		operation(op) {
 		conditionType = CT_Operand;
 	};
 private:
 	BYTE operation;
 	BYTE mapId;
+	BYTE mapId2;
 	bool EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);
@@ -485,13 +509,16 @@ class MapTierCondition : public Condition
 {
 public:
 	MapTierCondition(BYTE op,
-		BYTE mtier) : mapTier(mtier),
+		BYTE mtier,
+		BYTE mtier2) : mapTier(mtier),
+		mapTier2(mtier2),
 		operation(op) {
 		conditionType = CT_Operand;
 	};
 private:
 	BYTE operation;
 	BYTE mapTier;
+	BYTE mapTier2;
 	bool EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);
@@ -504,13 +531,16 @@ class CraftLevelCondition : public Condition
 {
 public:
 	CraftLevelCondition(BYTE op,
-		BYTE calvl) : craftLevel(calvl),
+		BYTE calvl,
+		BYTE calvl2) : craftLevel(calvl),
+		craftLevel2(calvl2),
 		operation(op) {
 		conditionType = CT_Operand;
 	};
 private:
 	BYTE operation;
 	BYTE craftLevel;
+	BYTE craftLevel2;
 	bool EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);
@@ -523,13 +553,16 @@ class AutomodCondition : public Condition
 {
 public:
 	AutomodCondition(BYTE op,
-		unsigned int automod) : automodID(automod),
+		unsigned int automod,
+		unsigned int automod2) : automodID(automod),
+		automodID2(automod2),
 		operation(op) {
 		conditionType = CT_Operand;
 	};
 private:
 	BYTE operation;
 	unsigned int automodID;
+	unsigned int automodID2;
 	bool EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);
@@ -605,13 +638,16 @@ class RequiredLevelCondition : public Condition
 {
 public:
 	RequiredLevelCondition(BYTE op,
-		BYTE rlvl) : requiredLevel(rlvl),
+		BYTE rlvl,
+		BYTE rlvl2) : requiredLevel(rlvl),
+		requiredLevel2(rlvl2),
 		operation(op) {
 		conditionType = CT_Operand;
 	};
 private:
 	BYTE operation;
 	BYTE requiredLevel;
+	BYTE requiredLevel2;
 	bool EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);
@@ -637,14 +673,17 @@ private:
 class EDCondition : public Condition
 {
 public:
-	EDCondition(BYTE         op,
-		unsigned int target) : operation(op),
-		targetED(target) {
+	EDCondition(BYTE op,
+		unsigned int target,
+		unsigned int target2) : operation(op),
+		targetED(target),
+		targetED2(target2) {
 		conditionType = CT_Operand;
 	};
 private:
 	BYTE         operation;
 	unsigned int targetED;
+	unsigned int targetED2;
 	bool         EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);
@@ -657,14 +696,17 @@ private:
 class DurabilityCondition : public Condition
 {
 public:
-	DurabilityCondition(BYTE         op,
-		unsigned int target) : operation(op),
-		targetDurability(target) {
+	DurabilityCondition(BYTE op,
+		unsigned int target,
+		unsigned int target2) : operation(op),
+		targetDurability(target),
+		targetDurability2(target2) {
 		conditionType = CT_Operand;
 	};
 private:
 	BYTE         operation;
 	unsigned int targetDurability;
+	unsigned int targetDurability2;
 	bool         EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);
@@ -676,17 +718,20 @@ private:
 class ChargedCondition : public Condition
 {
 public:
-	ChargedCondition(BYTE         op,
+	ChargedCondition(BYTE op,
 		unsigned int sk,
-		unsigned int target) : operation(op),
+		unsigned int target,
+		unsigned int target2) : operation(op),
 		skill(sk),
-		targetLevel(target) {
+		targetLevel(target),
+		targetLevel2(target2) {
 		conditionType = CT_Operand;
 	};
 private:
 	BYTE         operation;
 	unsigned int skill;
 	unsigned int targetLevel;
+	unsigned int targetLevel2;
 	bool         EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);
@@ -808,11 +853,13 @@ public:
 	CharStatCondition(unsigned int stat,
 		unsigned int stat2,
 		BYTE         op,
-		unsigned int target)
+		unsigned int target,
+		unsigned int target2)
 		: stat1(stat),
 		stat2(stat2),
 		operation(op),
-		targetStat(target) {
+		targetStat(target),
+		targetStat2(target2) {
 		conditionType = CT_Operand;
 	};
 private:
@@ -820,6 +867,7 @@ private:
 	unsigned int stat2;
 	BYTE         operation;
 	unsigned int targetStat;
+	unsigned int targetStat2;
 	bool         EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);
@@ -831,15 +879,18 @@ private:
 class DifficultyCondition : public Condition
 {
 public:
-	DifficultyCondition(BYTE         op,
-		unsigned int target)
+	DifficultyCondition(BYTE op,
+		unsigned int target,
+		unsigned int target2)
 		: operation(op),
-		targetDiff(target) {
+		targetDiff(target),
+		targetDiff2(target2) {
 		conditionType = CT_Operand;
 	};
 private:
 	BYTE         operation;
 	unsigned int targetDiff;
+	unsigned int targetDiff2;
 	bool         EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);
@@ -851,13 +902,18 @@ private:
 class FilterLevelCondition : public Condition
 {
 public:
-	FilterLevelCondition(BYTE op, unsigned int target)
-		: operation(op), filterLevel(target) {
+	FilterLevelCondition(BYTE op, 
+		unsigned int target,
+		unsigned int target2)
+		: operation(op), 
+		filterLevel(target),
+		filterLevel2(target2) {
 		conditionType = CT_Operand;
 	};
 private:
 	BYTE operation;
 	unsigned int filterLevel;
+	unsigned int filterLevel2;
 	bool EvaluateInternal(UnitItemInfo* uInfo, Condition* arg1, Condition* arg2);
 	bool EvaluateInternalFromPacket(ItemInfo* info, Condition* arg1, Condition* arg2);
 };
@@ -868,11 +924,13 @@ public:
 	ItemStatCondition(unsigned int stat,
 		unsigned int stat2,
 		BYTE         op,
-		unsigned int target)
+		unsigned int target,
+		unsigned int target2)
 		: itemStat(stat),
 		itemStat2(stat2),
 		operation(op),
-		targetStat(target) {
+		targetStat(target),
+		targetStat2(target2) {
 		conditionType = CT_Operand;
 	};
 private:
@@ -880,6 +938,7 @@ private:
 	unsigned int itemStat2;
 	BYTE         operation;
 	unsigned int targetStat;
+	unsigned int targetStat2;
 	bool         EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);
@@ -891,15 +950,18 @@ private:
 class ItemPriceCondition : public Condition
 {
 public:
-	ItemPriceCondition(BYTE         op,
-		unsigned int target)
+	ItemPriceCondition(BYTE op,
+		unsigned int target,
+		unsigned int target2)
 		: operation(op),
-		targetStat(target) {
+		targetStat(target),
+		targetStat2(target2) {
 		conditionType = CT_Operand;
 	};
 private:
 	BYTE         operation;
 	unsigned int targetStat;
+	unsigned int targetStat2;
 	bool         EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);
@@ -911,14 +973,17 @@ private:
 class ResistAllCondition : public Condition
 {
 public:
-	ResistAllCondition(BYTE         op,
-		unsigned int target) : operation(op),
-		targetStat(target) {
+	ResistAllCondition(BYTE op,
+		unsigned int target,
+		unsigned int target2) : operation(op),
+		targetStat(target),
+		targetStat2(target2) {
 		conditionType = CT_Operand;
 	};
 private:
 	BYTE         operation;
 	unsigned int targetStat;
+	unsigned int targetStat2;
 	bool         EvaluateInternal(UnitItemInfo* uInfo,
 		Condition* arg1,
 		Condition* arg2);

--- a/BH/Modules/MapNotify/MapNotify.cpp
+++ b/BH/Modules/MapNotify/MapNotify.cpp
@@ -8,6 +8,7 @@
 #include "../Item/ItemDisplay.h"
 #include "../../AsyncDrawBuffer.h"
 #include "../Item/Item.h"
+#include "../../Modules/GameSettings/GameSettings.h"
 
 #pragma optimize( "", off)
 
@@ -24,8 +25,6 @@ void MapNotify::LoadConfig() {
 }
 
 void MapNotify::ReadConfig() {
-	BH::config->ReadKey("Reload Config", "VK_NUMPAD0", reloadConfig);
-	BH::config->ReadKey("Reload Config Ctrl", "VK_R", reloadConfigCtrl);
 }
 
 void MapNotify::OnLoad() {
@@ -33,8 +32,9 @@ void MapNotify::OnLoad() {
 }
 
 void MapNotify::OnKey(bool up, BYTE key, LPARAM lParam, bool* block) {
+	GameSettings* settings = static_cast<GameSettings*>(BH::moduleManager->Get("gamesettings"));
 	bool ctrlState = ((GetKeyState(VK_LCONTROL) & 0x80) || (GetKeyState(VK_RCONTROL) & 0x80));
-	if (key == reloadConfigCtrl && ctrlState || key == reloadConfig) {
+	if (key == settings->reloadConfigCtrl && ctrlState || key == settings->reloadConfig) {
 		*block = true;
 		if (up)
 			BH::ReloadConfig();


### PR DESCRIPTION
This is #15 + #16 + a few more changes. The "between" operator change was big enough that I really wanted to test it with my other fixes, just to double check that there weren't any weird interactions. Also wrote better patch notes this time 😉 

---

New Features and improvements:
- Added Reload Config to the in-game settings menu
- Added EDEF which will filter Enhanced Defense
- Added EDAM which will filter Enhanced Damage
- Added GEMLEVEL (same as GEM)
- Added SOCKETS (same as SOCK)
- Added %SK#%, %OS#%, %CLSK#%, %TABSK#%, %MULTI#,#% skill value outputs
- Added named stat value outputs (%DEF%, %LIFE%, %MFIND%, %RES%, etc.)
- Renamed %STAT-#% to %STAT#% (now matches the input condition)
- All valid conditions will now work with the 'between' (~) operator
- Conditions with negative values should now work more intuitively (prior to this change, something like [REPLIFE>10] would also match items with negative Replenish Life, like Soul Drainer)

Bug Fixes:
- Fixed a bug with Enhanced Defense and Enhanced Damage sometimes returning 0
- Fixed a bug with 1H that prevented it from filtering "hand axe"
- Fixed a bug with EQ2 using the wrong armor group
- Fixed a bug with EQUIPPED which caused items in the shared stash to be incorrectly considered "equipped"
- Fixed a bug with SHOP that would sometimes cause the condition to incorrectly return true
- Fixed a bug with GEM/GEMLEVEL that prevented unstacked flawless/perfect from filtering properly