### PR TITLE
Move 0x9c packet intercept so we can use UnitAny

### DIFF
--- a/BH/BH.cpp
+++ b/BH/BH.cpp
@@ -219,6 +219,19 @@ bool BH::ReloadConfig() {
 		lootFilter->Parse();
 		moduleManager->ReloadConfig();
 		statsDisplay->LoadConfig();
+
+		// Remove nodraw flag from items when filter is reloaded. This is primarily just a QoL feature.
+		// Otherwise you'd have to reload the filter + leave and rejoin the area for hidden items to be visible again
+		UnitAny* player = D2CLIENT_GetPlayerUnit();
+		if (player && player->pAct && player->pPath->pRoom1->pRoom2->pLevel->dwLevelNo != 0) {
+			for (Room1* room1 = player->pAct->pRoom1; room1; room1 = room1->pRoomNext) {
+				for (UnitAny* unit = room1->pUnitFirst; unit; unit = unit->pListNext) {
+					if (unit->dwType == UNIT_ITEM && (unit->dwFlags2 & UNITFLAGEX_INVISIBLE)) {
+						unit->dwFlags2 &= ~UNITFLAGEX_INVISIBLE;
+					}
+				}
+			}
+		}
 	}
 	return true;
 }

--- a/BH/CommonStructs.h
+++ b/BH/CommonStructs.h
@@ -301,6 +301,19 @@ struct px5e
 	BYTE nButton;	//0x01
 	DWORD dwUnitId; //0x02
 };
+
+/*
+	Incoming item data
+*/
+struct px9c
+{
+	BYTE nHeader;			//0x00
+	BYTE nAction;			//0x01
+	BYTE nPacketSize;		//0x02
+	BYTE nComponent;		//0x03
+	UINT nItemId;			//0x04
+	BYTE pBitstream[244];	//0x08
+};
 #pragma pack(pop)
 
 

--- a/BH/D2Ptrs.h
+++ b/BH/D2Ptrs.h
@@ -109,6 +109,7 @@ FUNCPTR(D2CLIENT, GetCurrentInteractingNPC, UnitAny* __fastcall, (void), 0x46150
 FUNCPTR(D2CLIENT, GetSelectedUnit, UnitAny* __stdcall, (void), 0x51A80, 0x17280)
 FUNCPTR(D2CLIENT, GetCursorItem, UnitAny* __fastcall, (void), 0x16020, 0x144A0)
 FUNCPTR(D2CLIENT, GetMercUnit, UnitAny* __fastcall, (void), 0x97CD0, 0x9C0A0)
+FUNCPTR(D2CLIENT, ItemPacketBuildAction3_OldGround, void __stdcall, (px9c* pPacket), 0x86810)
 // FUNCPTR(D2CLIENT, UnitTestSelect, DWORD __stdcall, (UnitAny* pUnit, DWORD _1, DWORD _2, DWORD _3), 0x8D030) // unused but we need to use it
 
 FUNCPTR(D2CLIENT, SetSelectedUnit_I, void __fastcall, (UnitAny* pUnit), 0x51860, 0x17060)
@@ -315,6 +316,7 @@ ASMPTR(D2WIN, DrawTextBuffer, 0x12940, 0x134D0)
 
 ASMPTR(D2CLIENT, ParseStats_J, 0x54E10, 0x2CE40)
 ASMPTR(D2CLIENT, GetItemPropertiesString, 0x55B20);
+ASMPTR(D2CLIENT, ItemPacketBuildAction0_NewGround, 0x84BB0);
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/BH/D2Stubs.cpp
+++ b/BH/D2Stubs.cpp
@@ -1,5 +1,6 @@
 ﻿#include <Windows.h>
 #include "D2Ptrs.h"
+#include "Modules/Item/Item.h"
 
 DWORD __declspec(naked) __fastcall D2CLIENT_GetUnitName_STUB(DWORD UnitAny)
 {
@@ -109,5 +110,27 @@ __declspec (naked) int __fastcall ITEMS_GetItemPropertiesString_STUB(int nStatFi
 		pop esi
 		pop edi
 		retn 32
+	}
+}
+
+__declspec(naked) void __stdcall D2CLIENT_GetItemFromPacket_NewGround_STUB(px9c* packet)
+{
+	__asm
+	{
+		mov EAX, [esp + 4]									// packet
+
+		call D2CLIENT_ItemPacketBuildAction0_NewGround		// 0x84BB0
+		retn 4
+	}
+}
+
+__declspec(naked) void __stdcall D2CLIENT_GetItemFromPacketIntercept_NewGround_STUB()
+{
+	__asm
+	{
+		push EAX											// packet
+
+		call GetItemFromPacket_NewGround					// 0x84BB0
+		retn
 	}
 }

--- a/BH/D2Stubs.h
+++ b/BH/D2Stubs.h
@@ -10,3 +10,5 @@ CellFile* __fastcall D2CLIENT_LoadUiImage(CHAR* szPath);
 DWORD __fastcall D2CLIENT_ClickParty_ASM(RosterUnit* RosterUnit, DWORD Mode);
 void __fastcall D2CLIENT_PlaySound(int SoundNo);
 int __fastcall ITEMS_GetItemPropertiesString_STUB(int nStatFilter2, UnitAny* pItem, wchar_t* strBuffer, int nBufferLen, int a5, int nLayer, int nStatFilter, int a8, int a9, wchar_t* strBuffer2);
+void __stdcall D2CLIENT_GetItemFromPacket_NewGround_STUB(px9c* packet);
+void __stdcall D2CLIENT_GetItemFromPacketIntercept_NewGround_STUB();

--- a/BH/Modules/Item/Item.h
+++ b/BH/Modules/Item/Item.h
@@ -50,6 +50,7 @@
 #include "../../Drawing.h"
 
 struct UnitAny;
+struct UnitItemInfo;
 
 class Item : public Module {
 private:
@@ -87,6 +88,8 @@ public:
 	static BOOL PermShowItemsPatch2();
 	static BOOL PermShowItemsPatch3();
 
+	static void ProcessItemPacketFilterRules(UnitItemInfo* uInfo, px9c* pPacket);
+
 	static UnitAny* GetViewUnit();
 	static UnitAny* GetViewUnitAndDrawBox();
 
@@ -104,8 +107,10 @@ void PermShowItemsPatch1_ASM();
 void PermShowItemsPatch2_ASM();
 void PermShowItemsPatch3_ASM();
 void PermShowItemsPatch4_ASM();
-struct UnitItemInfo;
+
 int CreateUnitItemInfo(UnitItemInfo* uInfo, UnitAny* item);
+void __stdcall GetItemFromPacket_NewGround(px9c* packet);
+void __stdcall GetItemFromPacket_OldGround(px9c* packet);
 int ItemGetCorruptor(UnitAny* pItem);
 BOOL StatIsCorrupted(int nStat, int nCorruptor);
 

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -2307,7 +2307,11 @@ bool GoldCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	Condition* arg1,
 	Condition* arg2)
 {
-	return false; // can only evaluate this from packet data
+	if (uInfo->itemCode[0] == 'g' && uInfo->itemCode[1] == 'l' && uInfo->itemCode[2] == 'd')
+	{
+		return IntegerCompare(D2COMMON_GetUnitStat(uInfo->item, STAT_GOLD, 0), operation, goldAmount, goldAmount2);
+	}
+	return false;
 }
 
 bool GoldCondition::EvaluateInternalFromPacket(ItemInfo* info,

--- a/BH/Modules/ItemMover/ItemMover.cpp
+++ b/BH/Modules/ItemMover/ItemMover.cpp
@@ -621,66 +621,6 @@ void ItemMover::OnGamePacketRecv(BYTE* packet, bool* block) {
 			}
 			Unlock();
 		}
-
-		//if ((*BH::MiscToggles2)["Advanced Item Display"].state) {
-			//bool success = true;
-			//ItemInfo item = {};
-			//ParseItem((unsigned char*)packet, &item, &success);
-			//if ((item.action == ITEM_ACTION_NEW_GROUND || item.action == ITEM_ACTION_OLD_GROUND) && success) {
-			//	bool showOnMap = false;
-			//	auto color = UNDEFINED_COLOR;
-
-			//	for (vector<Rule*>::iterator it = MapRuleList.begin(); it != MapRuleList.end(); it++) {
-			//		// skip map and notification if ping level requirement is not met
-			//		int filterLevel = Item::GetFilterLevel();
-			//		if (filterLevel != 0 && (*it)->action.pingLevel < filterLevel && (*it)->action.pingLevel != -1) continue;
-
-			//		if ((*it)->Evaluate(NULL, &item)) {
-			//			auto action_color = (*it)->action.notifyColor;
-			//			// never overwrite color with an undefined color. never overwrite a defined color with dead color.
-			//			if (action_color != UNDEFINED_COLOR && (action_color != DEAD_COLOR || color == UNDEFINED_COLOR))
-			//				color = action_color;
-			//			showOnMap = true;
-			//			// break unless %CONTINUE% is used
-			//			if ((*it)->action.stopProcessing) break;
-			//		}
-			//	}
-			//	//PrintText(1, "Item on ground: %s, %s, %s, %X", item.name.c_str(), item.code, item.attrs->category.c_str(), item.attrs->flags);
-			//	if (showOnMap && !(*BH::MiscToggles2)["Item Detailed Notifications"].state) {
-			//		if (color == UNDEFINED_COLOR) {
-			//			color = ItemColorFromQuality(item.quality);
-			//		}
-			//		if ((*BH::MiscToggles2)["Item Drop Notifications"].state &&
-			//			item.action == ITEM_ACTION_NEW_GROUND &&
-			//			color != DEAD_COLOR
-			//			) {
-			//			PrintText(color, "%s%s Dropped",
-			//				item.name.c_str(),
-			//				(*BH::MiscToggles2)["Verbose Notifications"].state ? " \377c5drop" : ""
-			//			);
-			//		}
-			//		if ((*BH::MiscToggles2)["Item Close Notifications"].state &&
-			//			item.action == ITEM_ACTION_OLD_GROUND &&
-			//			color != DEAD_COLOR
-			//			) {
-			//			PrintText(color, "%s%s",
-			//				item.name.c_str(),
-			//				(*BH::MiscToggles2)["Verbose Notifications"].state ? " \377c5close" : ""
-			//			);
-			//		}
-			//	}
-			//	else if (!showOnMap) {
-			//		for (vector<Rule*>::iterator it = RuleList.begin(); it != RuleList.end(); it++) {
-			//			if ((*it)->Evaluate(NULL, &item)) {
-			//				if ((*it)->action.name.length() == 0 && Item::GetFilterLevel() > 0) {
-			//					*block = true;
-			//				}
-			//				if ((*it)->action.stopProcessing) break;
-			//			}
-			//		}
-			//	}
-			//}
-		//}
 		break;
 	}
 	case 0x9d:

--- a/BH/Modules/ItemMover/ItemMover.cpp
+++ b/BH/Modules/ItemMover/ItemMover.cpp
@@ -622,66 +622,65 @@ void ItemMover::OnGamePacketRecv(BYTE* packet, bool* block) {
 			Unlock();
 		}
 
-		if ((*BH::MiscToggles2)["Advanced Item Display"].state) {
-			bool success = true;
-			ItemInfo item = {};
-			ParseItem((unsigned char*)packet, &item, &success);
-			//PrintText(1, "Item packet: %s, %s, %X, %d, %d", item.name.c_str(), item.code, item.attrs->flags, item.sockets, GetDefense(&item));
-			if ((item.action == ITEM_ACTION_NEW_GROUND || item.action == ITEM_ACTION_OLD_GROUND) && success) {
-				bool showOnMap = false;
-				auto color = UNDEFINED_COLOR;
+		//if ((*BH::MiscToggles2)["Advanced Item Display"].state) {
+			//bool success = true;
+			//ItemInfo item = {};
+			//ParseItem((unsigned char*)packet, &item, &success);
+			//if ((item.action == ITEM_ACTION_NEW_GROUND || item.action == ITEM_ACTION_OLD_GROUND) && success) {
+			//	bool showOnMap = false;
+			//	auto color = UNDEFINED_COLOR;
 
-				for (vector<Rule*>::iterator it = MapRuleList.begin(); it != MapRuleList.end(); it++) {
-					// skip map and notification if ping level requirement is not met
-					int filterLevel = Item::GetFilterLevel();
-					if (filterLevel != 0 && (*it)->action.pingLevel < filterLevel && (*it)->action.pingLevel != -1) continue;
+			//	for (vector<Rule*>::iterator it = MapRuleList.begin(); it != MapRuleList.end(); it++) {
+			//		// skip map and notification if ping level requirement is not met
+			//		int filterLevel = Item::GetFilterLevel();
+			//		if (filterLevel != 0 && (*it)->action.pingLevel < filterLevel && (*it)->action.pingLevel != -1) continue;
 
-					if ((*it)->Evaluate(NULL, &item)) {
-						auto action_color = (*it)->action.notifyColor;
-						// never overwrite color with an undefined color. never overwrite a defined color with dead color.
-						if (action_color != UNDEFINED_COLOR && (action_color != DEAD_COLOR || color == UNDEFINED_COLOR))
-							color = action_color;
-						showOnMap = true;
-						// break unless %CONTINUE% is used
-						if ((*it)->action.stopProcessing) break;
-					}
-				}
-				//PrintText(1, "Item on ground: %s, %s, %s, %X", item.name.c_str(), item.code, item.attrs->category.c_str(), item.attrs->flags);
-				if (showOnMap && !(*BH::MiscToggles2)["Item Detailed Notifications"].state) {
-					if (color == UNDEFINED_COLOR) {
-						color = ItemColorFromQuality(item.quality);
-					}
-					if ((*BH::MiscToggles2)["Item Drop Notifications"].state &&
-						item.action == ITEM_ACTION_NEW_GROUND &&
-						color != DEAD_COLOR
-						) {
-						PrintText(color, "%s%s Dropped",
-							item.name.c_str(),
-							(*BH::MiscToggles2)["Verbose Notifications"].state ? " \377c5drop" : ""
-						);
-					}
-					if ((*BH::MiscToggles2)["Item Close Notifications"].state &&
-						item.action == ITEM_ACTION_OLD_GROUND &&
-						color != DEAD_COLOR
-						) {
-						PrintText(color, "%s%s",
-							item.name.c_str(),
-							(*BH::MiscToggles2)["Verbose Notifications"].state ? " \377c5close" : ""
-						);
-					}
-				}
-				else if (!showOnMap) {
-					for (vector<Rule*>::iterator it = RuleList.begin(); it != RuleList.end(); it++) {
-						if ((*it)->Evaluate(NULL, &item)) {
-							if ((*it)->action.name.length() == 0 && Item::GetFilterLevel() > 0) {
-								*block = true;
-							}
-							if ((*it)->action.stopProcessing) break;
-						}
-					}
-				}
-			}
-		}
+			//		if ((*it)->Evaluate(NULL, &item)) {
+			//			auto action_color = (*it)->action.notifyColor;
+			//			// never overwrite color with an undefined color. never overwrite a defined color with dead color.
+			//			if (action_color != UNDEFINED_COLOR && (action_color != DEAD_COLOR || color == UNDEFINED_COLOR))
+			//				color = action_color;
+			//			showOnMap = true;
+			//			// break unless %CONTINUE% is used
+			//			if ((*it)->action.stopProcessing) break;
+			//		}
+			//	}
+			//	//PrintText(1, "Item on ground: %s, %s, %s, %X", item.name.c_str(), item.code, item.attrs->category.c_str(), item.attrs->flags);
+			//	if (showOnMap && !(*BH::MiscToggles2)["Item Detailed Notifications"].state) {
+			//		if (color == UNDEFINED_COLOR) {
+			//			color = ItemColorFromQuality(item.quality);
+			//		}
+			//		if ((*BH::MiscToggles2)["Item Drop Notifications"].state &&
+			//			item.action == ITEM_ACTION_NEW_GROUND &&
+			//			color != DEAD_COLOR
+			//			) {
+			//			PrintText(color, "%s%s Dropped",
+			//				item.name.c_str(),
+			//				(*BH::MiscToggles2)["Verbose Notifications"].state ? " \377c5drop" : ""
+			//			);
+			//		}
+			//		if ((*BH::MiscToggles2)["Item Close Notifications"].state &&
+			//			item.action == ITEM_ACTION_OLD_GROUND &&
+			//			color != DEAD_COLOR
+			//			) {
+			//			PrintText(color, "%s%s",
+			//				item.name.c_str(),
+			//				(*BH::MiscToggles2)["Verbose Notifications"].state ? " \377c5close" : ""
+			//			);
+			//		}
+			//	}
+			//	else if (!showOnMap) {
+			//		for (vector<Rule*>::iterator it = RuleList.begin(); it != RuleList.end(); it++) {
+			//			if ((*it)->Evaluate(NULL, &item)) {
+			//				if ((*it)->action.name.length() == 0 && Item::GetFilterLevel() > 0) {
+			//					*block = true;
+			//				}
+			//				if ((*it)->action.stopProcessing) break;
+			//			}
+			//		}
+			//	}
+			//}
+		//}
 		break;
 	}
 	case 0x9d:


### PR DESCRIPTION
Previous mechanism to completely hide items:
- Intercept 0x9c packet before it gets sent to the D2Client functions that handle item creation
- Build `ItemInfo` from the packet bitstream (_all_ packet actions)
- Run loot filter rules using `ItemInfo` (if packet action == 0 or 3)
- If a match was found and the name was empty, then block the packet (i.e. don't pass it along to the client)

New mechanism:
 - Intercept 0x9c packet at the point where the item gets created (only for packet action 0 and 3)
 - Send the packet along to the client so the unit gets created
 - Get unit and build `UnitItemInfo`
 - Run loot filter rules using `UnitItemInfo`
 - If a match is found and the name is empty, add the `nodraw` flag to the item (`UNITFLAGEX_INVISIBLE`)

There's a _lot_ of code that can be removed now too, but I'll save that for a separate PR (`ParseItem` & `ProcessStat` in ItemMover, all of the `EvaluateInternalFromPacket` functions in ItemDisplay, etc.)

---
(public patch notes)
New Features and improvements:
- Hidden gold will now automatically be picked up

Bug Fixes:
- Fixed a bug with PRICE that would cause the condition to incorrectly return false in certain cases