### PR TITLE
Only process filter rules when we have item attrs

### DIFF
--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -388,10 +388,14 @@ void __stdcall GetItemFromPacket_NewGround(px9c* pPacket)
 	D2CLIENT_GetItemFromPacket_NewGround_STUB(pPacket);
 	UnitAny* pItem = D2CLIENT_FindServerSideUnit(pPacket->nItemId, UNIT_ITEM);
 	UnitItemInfo uInfo;
-	if (CreateUnitItemInfo(&uInfo, pItem)) {
+	if (!CreateUnitItemInfo(&uInfo, pItem))
+	{
+		Item::ProcessItemPacketFilterRules(&uInfo, pPacket);
+	}
+	else
+	{
 		HandleUnknownItemCode(uInfo.itemCode, "from packet");
 	}
-	Item::ProcessItemPacketFilterRules(&uInfo, pPacket);
 
 	return;
 }
@@ -402,10 +406,14 @@ void __stdcall GetItemFromPacket_OldGround(px9c* pPacket)
 	D2CLIENT_ItemPacketBuildAction3_OldGround(pPacket);
 	UnitAny* pItem = D2CLIENT_FindServerSideUnit(pPacket->nItemId, UNIT_ITEM);
 	UnitItemInfo uInfo;
-	if (CreateUnitItemInfo(&uInfo, pItem)) {
+	if (!CreateUnitItemInfo(&uInfo, pItem))
+	{
+		Item::ProcessItemPacketFilterRules(&uInfo, pPacket);
+	}
+	else
+	{
 		HandleUnknownItemCode(uInfo.itemCode, "from packet");
 	}
-	Item::ProcessItemPacketFilterRules(&uInfo, pPacket);
 
 	return;
 }


### PR DESCRIPTION
The old packet behavior was already doing this, I just missed it when I moved things over.

```c++
if (ItemAttributeMap.find(item->code) == ItemAttributeMap.end()) {
	HandleUnknownItemCode(item->code, "from packet");
	*success = false;
	return;
}
```
It would only trigger the loot filter rules when `success == true`, so this code block would prevent the crashes we've been seeing.