### PR TITLE
Added rollback skills to IAS breakpoint calc

### DIFF
--- a/BH/D2Ptrs.h
+++ b/BH/D2Ptrs.h
@@ -389,6 +389,7 @@ FUNCPTR(D2COMMON, 10595_UNITS_InitUnitMode, BOOL __stdcall, (UnitAny* pUnit), -1
 
 FUNCPTR(D2COMMON, 10507_UNITS_GetRightSkill, Skill* __stdcall, (UnitAny* pUnit), -10507);
 FUNCPTR(D2COMMON, 10030_SKILLS_GetSeqNumFromSkill, int __fastcall, (UnitAny* pUnit, Skill* pSkill), 0x4EC50);
+FUNCPTR(D2COMMON, 10786_SKILLS_EvaluateSkillFormula, int __stdcall, (UnitAny* pUnit, DWORD nCalc, int nSkillId, int nSkillLevel), -10786);
 FUNCPTR(D2COMMON, 10194_DATATBLS_GetMonSeqTableRecord, SequenceInfo* __stdcall, (int nSequence), -10194);
 ASMPTR(D2COMMON, GetSequenceInfo, 0x2E840);
 ASMPTR(D2COMMON, GetSequenceIndex, 0x2E790);

--- a/BH/D2Structs.h
+++ b/BH/D2Structs.h
@@ -418,12 +418,8 @@ struct Light {
 	int* pnStaticMap;				//0x30
 };
 
-struct SkillInfo {
-	WORD wSkillId;					//0x00
-};
-
 struct Skill {
-	SkillInfo* pSkillInfo;			//0x00
+	SkillsTxt* pSkillInfo;			//0x00
 	Skill* pNextSkill;				//0x04
 	int mode;						//0x08
 	DWORD flags;					//0x0C

--- a/BH/Drawing/Stats/StatsDisplay.cpp
+++ b/BH/Drawing/Stats/StatsDisplay.cpp
@@ -1036,20 +1036,8 @@ void StatsDisplay::GetIASBreakpointString(UnitAny* pUnit,
 		int nUnitID = pUnit->dwTxtFileNo;
 		AnimDataRecord* pAnimData = NULL;
 
-		if (pRightSkill->mode == PLAYER_MODE_SEQUENCE || pRightSkill->pSkillInfo->bSeqNum == 19)
+		if (pRightSkill->mode == PLAYER_MODE_SEQUENCE)
 		{
-			// Hide Dragon Talon until we have their frames worked out
-			if (pRightSkill->pSkillInfo->bSeqNum == 19)
-			{
-				Texthook::Draw(x,
-					*pY,
-					None,
-					6,
-					Gold,
-					"IAS (Frames): N/A (Work in Progress)");
-				return;
-			}
-
 			int nSeqNum = D2COMMON_10030_SKILLS_GetSeqNumFromSkill(pUnit, pRightSkill);
 			int nSeqIndex = D2COMMON_GetSequenceIndex_STUB(pUnit);
 			if (&(p_D2COMMON_PlayerSequenceDataTable[nSeqNum]) == NULL)
@@ -1173,7 +1161,6 @@ void StatsDisplay::GetIASBreakpointString(UnitAny* pUnit,
 			}
 			nTotalHits = D2COMMON_10786_SKILLS_EvaluateSkillFormula(pUnit, pRightSkill->pSkillInfo->dwCalc1, pRightSkill->pSkillInfo->wSkillId, pRightSkill->skillLevel);
 
-			// TODO: need to figure out how action frames work with the Dragon Talon sequence
 			if (pAnimData)
 			{
 				for (int i = 0; i < nFrames; ++i)

--- a/BH/Drawing/Stats/StatsDisplay.cpp
+++ b/BH/Drawing/Stats/StatsDisplay.cpp
@@ -1069,7 +1069,6 @@ void StatsDisplay::GetIASBreakpointString(UnitAny* pUnit,
 			nAttackRate = D2COMMON_GetUnitStat(pUnit, STAT_ATTACKRATE, 0);
 			nAnimAcceleration = nFrameMinAccr + nAttackRate - 30;
 			nMinAnimAcceleration = nAttackRate - 30;
-			nMaxAnimAcceleration = 145;
 		}
 		else if (pUnit->dwType == UNIT_MONSTER && pRightSkill->mode == NPC_MODE_SEQUENCE)
 		{
@@ -1081,7 +1080,6 @@ void StatsDisplay::GetIASBreakpointString(UnitAny* pUnit,
 			nAttackRate = D2COMMON_GetUnitStat(pUnit, STAT_ATTACKRATE, 0);
 			nAnimAcceleration = nFrameMinAccr + nAttackRate;
 			nMinAnimAcceleration = nAttackRate;
-			nMaxAnimAcceleration = 175;
 		}
 		else
 		{

--- a/BH/Drawing/Stats/StatsDisplay.cpp
+++ b/BH/Drawing/Stats/StatsDisplay.cpp
@@ -1022,26 +1022,34 @@ void StatsDisplay::GetIASBreakpointString(UnitAny* pUnit,
 		int nMaxAnimAcceleration = 175;
 		int nFrameMinAccr = 0;
 		int nAttackRate = 0;
+		int nAnimRate = 0;
+		int nMinAnimRate = 0;
+		int nMaxAnimRate = 0;
 
+		int nSkillRollback = 0;
+		int nTotalHits = 0;
+		int nActionFrame = 0;
+
+		int nSkillId = pRightSkill->pSkillInfo->wSkillId;
 		int nMode = 0;
 		int nAnimType = pUnit->dwType;
 		int nUnitID = pUnit->dwTxtFileNo;
 		AnimDataRecord* pAnimData = NULL;
 
-		// Disable rollback skill calc for now until implemented
-		if (rollback_skills.find(pRightSkill->pSkillInfo->wSkillId) != rollback_skills.end())
+		if (pRightSkill->mode == PLAYER_MODE_SEQUENCE || pRightSkill->pSkillInfo->bSeqNum == 19)
 		{
-			Texthook::Draw(x,
-				*pY,
-				None,
-				6,
-				Gold,
-				"IAS (Frames): N/A (Work in Progress)");
-			return;
-		}
+			// Hide Dragon Talon until we have their frames worked out
+			if (pRightSkill->pSkillInfo->bSeqNum == 19)
+			{
+				Texthook::Draw(x,
+					*pY,
+					None,
+					6,
+					Gold,
+					"IAS (Frames): N/A (Work in Progress)");
+				return;
+			}
 
-		if (pRightSkill->mode == PLAYER_MODE_SEQUENCE)
-		{
 			int nSeqNum = D2COMMON_10030_SKILLS_GetSeqNumFromSkill(pUnit, pRightSkill);
 			int nSeqIndex = D2COMMON_GetSequenceIndex_STUB(pUnit);
 			if (&(p_D2COMMON_PlayerSequenceDataTable[nSeqNum]) == NULL)
@@ -1075,7 +1083,7 @@ void StatsDisplay::GetIASBreakpointString(UnitAny* pUnit,
 			nMinAnimAcceleration = nAttackRate - 30;
 			nMaxAnimAcceleration = 145;
 		}
-		else if (pUnit->dwType == UNIT_MONSTER && pRightSkill->mode == PLAYER_MODE_USESKILL2)
+		else if (pUnit->dwType == UNIT_MONSTER && pRightSkill->mode == NPC_MODE_SEQUENCE)
 		{
 			int nSeqNum = D2COMMON_10030_SKILLS_GetSeqNumFromSkill(pUnit, pRightSkill);
 			SequenceInfo* pMonSeqInfo = D2COMMON_10194_DATATBLS_GetMonSeqTableRecord(nSeqNum);
@@ -1090,7 +1098,8 @@ void StatsDisplay::GetIASBreakpointString(UnitAny* pUnit,
 		else
 		{
 			nMode = pRightSkill->mode;
-			if (nMode == PLAYER_MODE_CAST)
+			// Ignore spells. Ignore auras/Force Move
+			if (nMode == PLAYER_MODE_CAST || nMode == PLAYER_MODE_RUN)
 			{
 				Texthook::Draw(x,
 					*pY,
@@ -1113,6 +1122,17 @@ void StatsDisplay::GetIASBreakpointString(UnitAny* pUnit,
 					"IAS (Frames): N/A");
 				return;
 			}
+			// Hide Werewolf & Werebear until we have their frames worked out
+			if (nUnitID == 430 || nUnitID == 431)
+			{
+				Texthook::Draw(x,
+					*pY,
+					None,
+					6,
+					Gold,
+					"IAS (Frames): N/A (Work in Progress)");
+				return;
+			}
 
 			nFrames = pAnimData->dwFrames;
 			nAnimSpeed = pAnimData->dwAnimSpeed;
@@ -1122,6 +1142,49 @@ void StatsDisplay::GetIASBreakpointString(UnitAny* pUnit,
 			nAttackRate = D2COMMON_GetUnitStat(pUnit, STAT_ATTACKRATE, 0);
 			nAnimAcceleration = nFrameMinAccr + nAttackRate;
 			nMinAnimAcceleration = nAttackRate;
+		}
+
+
+		if (rollback_skills.find(nSkillId) != rollback_skills.end())
+		{
+			switch (pRightSkill->pSkillInfo->wSkillId)
+			{
+			case 26: // Strafe
+			{
+				nSkillRollback = pRightSkill->pSkillInfo->dwParam6;
+				break;
+			}
+			case 30:  // Fend
+			case 106: // Zeal
+			case 248: // Fury
+			{
+				nSkillRollback = pRightSkill->pSkillInfo->dwParam2;
+				break;
+			}
+			case 255: // Dragon Talon
+			{
+				nSkillRollback = 100; // Hardcoded, not in skillstxt
+				break;
+			}
+			default:
+			{
+				break;
+			}
+			}
+			nTotalHits = D2COMMON_10786_SKILLS_EvaluateSkillFormula(pUnit, pRightSkill->pSkillInfo->dwCalc1, pRightSkill->pSkillInfo->wSkillId, pRightSkill->skillLevel);
+
+			// TODO: need to figure out how action frames work with the Dragon Talon sequence
+			if (pAnimData)
+			{
+				for (int i = 0; i < nFrames; ++i)
+				{
+					if (pAnimData->dwAnimData[i])
+					{
+						nActionFrame = i;
+						break;
+					}
+				}
+			}
 		}
 
 		if (D2COMMON_UnitCanDualWield(pUnit))
@@ -1193,9 +1256,27 @@ void StatsDisplay::GetIASBreakpointString(UnitAny* pUnit,
 		if (nAnimAcceleration > nMaxAnimAcceleration) nAnimAcceleration = nMaxAnimAcceleration;
 		if (nAnimSpeed == 0) nAnimSpeed = 256;
 
-		nMinFrames = ceil(((((double)nFrames - (double)nFrameBonus) * 256) / (double)((nAnimSpeed * nMaxAnimAcceleration) / 100))) - 1;
-		nMaxFrames = ceil(((((double)nFrames - (double)nFrameBonus) * 256) / (double)((nAnimSpeed * nMinAnimAcceleration) / 100))) - 1;
-		nAnimFrames = ceil(((((double)nFrames - (double)nFrameBonus) * 256) / (double)((nAnimSpeed * nAnimAcceleration) / 100))) - 1;
+		nMinAnimRate = ((nAnimSpeed * nMaxAnimAcceleration) / 100);
+		nMaxAnimRate = ((nAnimSpeed * nMinAnimAcceleration) / 100);
+		nAnimRate = ((nAnimSpeed * nAnimAcceleration) / 100);
+
+		nMinFrames = ceil(((((double)nFrames - (double)nFrameBonus) * 256) / (double)nMinAnimRate)) - 1;
+		nMaxFrames = ceil(((((double)nFrames - (double)nFrameBonus) * 256) / (double)nMaxAnimRate)) - 1;
+		nAnimFrames = ceil(((((double)nFrames - (double)nFrameBonus) * 256) / (double)nAnimRate)) - 1;
+
+		std::vector<int> nMinActionFrames(nTotalHits);
+		std::vector<int> nMaxActionFrames(nTotalHits);
+		std::vector<int> nAnimActionFrames(nTotalHits);
+
+		std::vector<int> nCurrentActionFrame(nTotalHits);
+		std::vector<int> nPreviousActionFrame(nTotalHits);
+
+		if (rollback_skills.find(nSkillId) != rollback_skills.end())
+		{
+			nMinActionFrames = GetRollbackSkillFrames(nMinActionFrames, nActionFrame, nFrames, nFrameBonus, nMinAnimRate, nSkillRollback);
+			nMaxActionFrames = GetRollbackSkillFrames(nMaxActionFrames, nActionFrame, nFrames, nFrameBonus, nMaxAnimRate, nSkillRollback);
+			nAnimActionFrames = GetRollbackSkillFrames(nAnimActionFrames, nActionFrame, nFrames, nFrameBonus, nAnimRate, nSkillRollback);
+		}
 
 		std::string bpString = bpCharString;
 		int nIASBP = 0;
@@ -1207,11 +1288,33 @@ void StatsDisplay::GetIASBreakpointString(UnitAny* pUnit,
 		{
 			nBaseIAS = (double)i - (double)nMinAnimAcceleration;
 			nIASBP = ceil((120 * nBaseIAS) / (120 - nBaseIAS));
-			nCurrentFrames = ceil(((((double)nFrames - (double)nFrameBonus) * 256) / (double)((nAnimSpeed * i) / 100))) - 1;
-			if (nCurrentFrames == nPreviousFrameBP) continue;
+			nAnimRate = (nAnimSpeed * i) / 100;
 
-			nPreviousFrameBP = nCurrentFrames;
-			if (nCurrentFrames == nAnimFrames)
+			if (rollback_skills.find(nSkillId) != rollback_skills.end())
+			{
+				nCurrentActionFrame = GetRollbackSkillFrames(nCurrentActionFrame, nActionFrame, nFrames, nFrameBonus, nAnimRate, nSkillRollback);
+				if (nCurrentActionFrame == nPreviousActionFrame) continue;
+				nPreviousActionFrame = nCurrentActionFrame;
+			}
+			else
+			{
+				nCurrentFrames = ceil(((((double)nFrames - (double)nFrameBonus) * 256) / (double)nAnimRate)) - 1;
+				if (nCurrentFrames == nPreviousFrameBP) continue;
+				nPreviousFrameBP = nCurrentFrames;
+			}
+
+			if (rollback_skills.find(nSkillId) != rollback_skills.end() && nCurrentActionFrame == nAnimActionFrames)
+			{
+				bpString += "ÿc8";
+				bpString += std::to_string(nIASBP) + " (";
+				for (int i = 0; i < nCurrentActionFrame.size() - 1; i++)
+				{
+					bpString += std::to_string(nCurrentActionFrame[i]) + "|";
+				}
+				bpString += std::to_string(nCurrentActionFrame.back()) + ")";
+				bpString += "ÿc0";
+			}
+			else if (nCurrentFrames == nAnimFrames)
 			{
 				bpString += "ÿc8";
 				bpString += std::to_string(nIASBP) + " (" + std::to_string(nCurrentFrames) + ")";
@@ -1226,8 +1329,24 @@ void StatsDisplay::GetIASBreakpointString(UnitAny* pUnit,
 
 		nBaseIAS = (double)nMaxAnimAcceleration - (double)nMinAnimAcceleration;
 		nIASBP = ceil((120 * nBaseIAS) / (120 - nBaseIAS));
+		// TODO: nCurrentFrames here appears to be identical to nMinFrames. Is this a mistake? Should this be something else?
 		nCurrentFrames = ceil(((((double)nFrames - (double)nFrameBonus) * 256) / (double)((nAnimSpeed * nMaxAnimAcceleration) / 100))) - 1;
-		if (nCurrentFrames != nPreviousFrameBP)
+
+		if (rollback_skills.find(nSkillId) != rollback_skills.end() && nMinActionFrames != nPreviousActionFrame)
+		{
+			if (nMinActionFrames == nAnimActionFrames) bpString += "ÿc8";
+			bpString += std::to_string(nIASBP);
+			if (nMinActionFrames == nAnimActionFrames)
+			{
+				bpString += " (";
+				for (int i = 0; i < nMinActionFrames.size() - 1; i++)
+				{
+					bpString += std::to_string(nMinActionFrames[i]) + "|";
+				}
+				bpString += std::to_string(nMinActionFrames.back()) + ")";
+			}
+		}
+		else if (nCurrentFrames != nPreviousFrameBP && nPreviousFrameBP != 0)
 		{
 			if (nMinFrames == nAnimFrames) bpString += "ÿc8";
 			bpString += std::to_string(nIASBP);
@@ -1311,6 +1430,44 @@ void StatsDisplay::GetIASBreakpointString(UnitAny* pUnit,
 			Gold,
 			"IAS (Frames): N/A");
 	}
+}
+
+std::vector<int> StatsDisplay::GetRollbackSkillFrames(std::vector<int> nAnimFrames, int nActionFrame, int nTotalFrames, int nFrameBonus, int nAnimRate, int nSkillRollback)
+{
+	int nRollbackBase = 0;
+	int nRollbackStartFrame = 0;
+	int nTotalHits = nAnimFrames.size();
+	std::vector<int> nActionFrames256(nTotalHits);
+
+	// Calculate the first action frame
+	nActionFrames256[0] = (nFrameBonus * 256) + ceil((((double)nActionFrame - (double)nFrameBonus) * 256) / (double)nAnimRate) * nAnimRate;
+	for (int i = 1; i <= nTotalHits - 1; i++)
+	{
+		nRollbackBase = ((nActionFrames256[i - 1]) >> 8) * (100 - nSkillRollback) / 100;  // Rollback the skill to n frame number
+		nRollbackStartFrame = (nRollbackBase * 256) + nAnimRate;  // The starting frame for the next action
+		nActionFrames256[i] = (nRollbackBase * 256) + ceil((((double)nActionFrame - (double)nRollbackBase) * 256) / (double)nAnimRate) * nAnimRate;  // The following action frame
+
+		// Get frame values for middle frame actions
+		nAnimFrames[i] = 1;
+		while (nRollbackStartFrame < nActionFrames256[i])
+		{
+			nRollbackStartFrame += nAnimRate;
+			nAnimFrames[i] += 1;
+		}
+	}
+	// Calculate the last frame:
+	nActionFrames256.back() = ((nRollbackBase * 256) + ceil((((double)nTotalFrames - (double)nRollbackBase) * 256) / (double)nAnimRate) * nAnimRate) - (nAnimRate * 2);
+
+	// Get frame value for last frame action
+	while (nRollbackStartFrame < nActionFrames256.back())
+	{
+		nRollbackStartFrame += nAnimRate;
+		nAnimFrames.back() += 1;
+	}
+	// Get frame value for the first frame action
+	nAnimFrames[0] = ceil((nActionFrames256[0] - (nFrameBonus * 256)) / (double)nAnimRate) + 1;
+
+	return nAnimFrames;
 }
 
 WeaponType StatsDisplay::GetCurrentWeaponType(Inventory* inventory)

--- a/BH/Drawing/Stats/StatsDisplay.h
+++ b/BH/Drawing/Stats/StatsDisplay.h
@@ -133,6 +133,12 @@ namespace Drawing
 			char* bpCharString);
 
 		void StatsDisplay::GetIASBreakpointString(UnitAny* pUnit, char* bpCharString, int x, int* y);
+		static std::vector<int> StatsDisplay::GetRollbackSkillFrames(std::vector<int> nAnimFrames,
+			int nActionFrame,
+			int nTotalFrames,
+			int nFrameBonus,
+			int nAnimRate,
+			int nSkillRollback);
 		static WeaponType  GetCurrentWeaponType(Inventory* inventory);
 		static int GetActIndex(int map_number, int difficulty);
 		static WeaponType GetCurrentWeaponType(int dw_text_file_number);


### PR DESCRIPTION
This first pass supports Strafe, Fend, Zeal, and Dragon Talon.
Fury requires Druid wereform updates (their IAS works differently from normal)

Some notes from my testing:
- Frame 0 _is_ included in the attack animation, at the beginning (shocker). This is why you'll see a difference in frames if you compare it to the PoD calculator for example (they seem to add frame 0 onto the end for some reason). For example, both our calc and the PoD calc show 14 frames for a basic Pally attack, and you can only reach 14 frames _if_ you include frame 0.
![image](https://user-images.githubusercontent.com/72409387/232146737-7f3caf78-0a6b-4471-9b61-34528e243610.png)

- And speaking of frame 0, there seems to be some misunderstood behaviors in the community around it. Namely that consecutive attacks will be 1 frame faster because the final frame of attack 1 will carry over to attack 2. This doesn't appear to be the case. I tested 10 attacks in a row and they all had the same number of frames.
- Having said that, in rare cases frame 0 _does_ seem to get skipped. I haven't been able to figure out why it happens but I know it isn't from consecutive attacks because it can happen on the first attack in a chain. Maybe it gets skipped if the idle animation frame 0 would happen at the same time? Hard to say. May also just be an artifact from my test setup.


- 10WSM crossbow has some interesting breakpoints
  - 50 ias: 9|4|4|4|10
  - 58 ias: 8|4|4|4|11

So the total number of frames in the animation doesn't change, but the first hit happens a frame sooner.

---

This is the code I used for testing. I put it inside of `MapNotify::OnDraw()` since it's _always_ looping. It'll print out the frames only when using specific animations (otherwise you just get spammed with idle and running animation frames)

```c++
int previousFrame = -1;

	std::string animName = player->pGfxAnimData->szAnimDataName;
	if (player->pGfxAnimData && 
		(animName == "AMA1BOW" || animName == "40S3HTH" || animName == "40A1HTH" || animName == "40A2HTH" || animName == "AMA1XBW"
			|| animName == "PAA11HS" || animName == "AMA12HT" || animName == "AIKKHT1"))
	{
		if (player->dwGfxFrame != previousFrame)
		{
			if (player->bActionFrame)
			{
				PrintText(4, "dwGfxFrame:%i actionFrame:%i rate:%i", player->dwGfxFrame, player->bActionFrame, player->wFrameRate);
			}
			else
			{
				PrintText(1, "dwGfxFrame:%i rate:%i", player->dwGfxFrame, player->wFrameRate);
			}
			previousFrame = player->dwGfxFrame;
		}
	}
```

Here's another example with Zeal at the fastest breakpoint:
![image](https://user-images.githubusercontent.com/72409387/232147547-0169998a-6e79-430b-96b4-2248acd9b1f1.png)
(end wall-of-text)