### PR TITLE
Added hotkey to cycle through filter levels

### DIFF
--- a/BH/BH.cpp
+++ b/BH/BH.cpp
@@ -105,7 +105,7 @@ void BH::Initialize()
 		SetWindowLong(D2GFX_GetHwnd(), GWL_WNDPROC, (LONG)GameWindowEvent);
 		});
 
-	settingsUI = new Drawing::UI(SETTINGS_TEXT, 400, 336);
+	settingsUI = new Drawing::UI(SETTINGS_TEXT, 400, 366);
 
 	Task::InitializeThreadPool(2);
 

--- a/BH/BH.cpp
+++ b/BH/BH.cpp
@@ -105,7 +105,7 @@ void BH::Initialize()
 		SetWindowLong(D2GFX_GetHwnd(), GWL_WNDPROC, (LONG)GameWindowEvent);
 		});
 
-	settingsUI = new Drawing::UI(SETTINGS_TEXT, 400, 321);
+	settingsUI = new Drawing::UI(SETTINGS_TEXT, 400, 336);
 
 	Task::InitializeThreadPool(2);
 

--- a/BH/Modules/GameSettings/GameSettings.cpp
+++ b/BH/Modules/GameSettings/GameSettings.cpp
@@ -181,6 +181,18 @@ void GameSettings::LoadInteractionTab() {
 		"Place 1 unstacked item");
 	colored_text->SetColor(Gold);
 
+	y += 20;
+	colored_text = new Drawing::Texthook(tab, x, y,
+		"Changing filter levels");
+
+	y += 15;
+	colored_text = new Drawing::Texthook(tab, x + indent, y,
+		"Ctrl+Numpad [0 - 9]");
+	colored_text->SetColor(Gold);
+	colored_text = new Drawing::Texthook(tab, x + indent + offset, y,
+		"Set filter level");
+	colored_text->SetColor(Gold);
+
 	// Auras
 	y += 20;
 	new Drawing::Texthook(tab, x, (y), "Auras (only for top 3 players)");

--- a/BH/Modules/GameSettings/GameSettings.cpp
+++ b/BH/Modules/GameSettings/GameSettings.cpp
@@ -223,8 +223,9 @@ void GameSettings::OnLoad() {
 }
 
 void GameSettings::OnKey(bool up, BYTE key, LPARAM lParam, bool* block) {
+	bool ctrlState = ((GetKeyState(VK_LCONTROL) & 0x80) || (GetKeyState(VK_RCONTROL) & 0x80));
 	for (map<string, Toggle>::iterator it = Toggles.begin(); it != Toggles.end(); it++) {
-		if (key == (*it).second.toggle) {
+		if (key == (*it).second.toggle && !ctrlState) {
 			*block = true;
 			if (up) {
 				(*it).second.state = !(*it).second.state;

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -584,6 +584,7 @@ void Item::LoadConfig() {
 	BH::config->ReadKey("Decrease Filter Level", "None", filterLevelDecKey);
 	BH::config->ReadKey("Restore Prev Filter Level", "None", filterLevelPrevKey);
 	BH::config->ReadInt("Filter Level", filterLevelSetting, 1);
+	BH::config->ReadInt("Previous Filter Level", prevFilterLevelSetting, 0);
 }
 
 void Item::DrawSettings() {
@@ -791,7 +792,7 @@ void Item::OnKey(bool up, BYTE key, LPARAM lParam, bool* block) {
 	if (key == filterLevelPrevKey) {
 		*block = true;
 		if (!up && D2CLIENT_GetPlayerUnit() &&
-			prevFilterLevelSetting < ItemFilterNames.size() - 1) {
+			prevFilterLevelSetting < ItemFilterNames.size()) {
 			ChangeFilterLevels(prevFilterLevelSetting);
 		}
 		return;
@@ -806,7 +807,7 @@ void Item::OnKey(bool up, BYTE key, LPARAM lParam, bool* block) {
 	}
 
 	for (map<string, Toggle>::iterator it = Toggles.begin(); it != Toggles.end(); it++) {
-		if (key == (*it).second.toggle) {
+		if (key == (*it).second.toggle && !ctrlState) {
 			*block = true;
 			if (up) {
 				(*it).second.state = !(*it).second.state;

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -796,8 +796,8 @@ void Item::OnKey(bool up, BYTE key, LPARAM lParam, bool* block) {
 		}
 		return;
 	}
-	bool shiftState = ((GetKeyState(VK_LSHIFT) & 0x80) || (GetKeyState(VK_RSHIFT) & 0x80));
-	if (shiftState && key >= VK_NUMPAD0 && key <= VK_NUMPAD9) {
+	bool ctrlState = ((GetKeyState(VK_LCONTROL) & 0x80) || (GetKeyState(VK_RCONTROL) & 0x80));
+	if (ctrlState && key >= VK_NUMPAD0 && key <= VK_NUMPAD9) {
 		*block = true;
 		unsigned int targetLevel = key - 0x60;
 		if (!up && D2CLIENT_GetPlayerUnit() && targetLevel < ItemFilterNames.size())

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -580,9 +580,9 @@ void Item::LoadConfig() {
 
 	ItemDisplay::UninitializeItemRules();
 
-	BH::config->ReadKey("Increase Filter Strictness", "None", filterLevelIncKey);
-	BH::config->ReadKey("Decrease Filter Strictness", "None", filterLevelDecKey);
-	BH::config->ReadKey("Restore Prev Filter Strictness", "None", filterLevelPrevKey);
+	BH::config->ReadKey("Increase Filter Level", "None", filterLevelIncKey);
+	BH::config->ReadKey("Decrease Filter Level", "None", filterLevelDecKey);
+	BH::config->ReadKey("Restore Prev Filter Level", "None", filterLevelPrevKey);
 	BH::config->ReadInt("Filter Level", filterLevelSetting, 1);
 }
 
@@ -660,17 +660,17 @@ void Item::DrawSettings() {
 	new Keyhook(settingsTab, GameSettings::KeyHookOffset, y + 2, &Toggles["Verbose Notifications"].toggle, "");
 	y += 15;
 
-	colored_text = new Drawing::Texthook(settingsTab, x, (y), "Increase Filter Strictness");
+	colored_text = new Drawing::Texthook(settingsTab, x, (y), "Increase Filter Level");
 	colored_text->SetColor(Gold);
 	new Drawing::Keyhook(settingsTab, GameSettings::KeyHookOffset, y + 2, &filterLevelIncKey, "");
 	y += 15;
 
-	colored_text = new Drawing::Texthook(settingsTab, x, (y), "Decrease Filter Strictness");
+	colored_text = new Drawing::Texthook(settingsTab, x, (y), "Decrease Filter Level");
 	colored_text->SetColor(Gold);
 	new Drawing::Keyhook(settingsTab, GameSettings::KeyHookOffset, y + 2, &filterLevelDecKey, "");
 	y += 15;
 
-	colored_text = new Drawing::Texthook(settingsTab, x, (y), "Restore Previous Filter Strictness");
+	colored_text = new Drawing::Texthook(settingsTab, x, (y), "Restore Previous Filter Level");
 	colored_text->SetColor(Gold);
 	new Drawing::Keyhook(settingsTab, GameSettings::KeyHookOffset, y + 2, &filterLevelPrevKey, "");
 	y += 15;
@@ -719,7 +719,7 @@ void Item::ChangeFilterLevels(int newLevel) {
 	filterLevelSetting = newLevel;
 	
 	if (filterLevelSetting == 0)
-		PrintText(TextColor::Gold, "Filter level: ÿc00 - Show All Items");
+		PrintText(TextColor::Gold, "Filter level: ÿc50 - Show All Items");
 	else
 		PrintText(TextColor::Gold, "Filter level: ÿc0%s", &ItemFilterNames[filterLevelSetting]);
 

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -579,6 +579,7 @@ void Item::LoadConfig() {
 
 	ItemDisplay::UninitializeItemRules();
 
+	BH::config->ReadKey("Cycle Filter Level", "VK_ADD", filterCycleKey);
 	BH::config->ReadInt("Filter Level", filterLevelSetting, 1);
 }
 
@@ -654,6 +655,11 @@ void Item::DrawSettings() {
 
 	new Checkhook(settingsTab, x, y, &Toggles["Verbose Notifications"].state, "Verbose Notifications");
 	new Keyhook(settingsTab, GameSettings::KeyHookOffset, y + 2, &Toggles["Verbose Notifications"].toggle, "");
+	y += 15;
+
+	colored_text = new Drawing::Texthook(settingsTab, x, (y), "Cycle Through Filter Levels");
+	colored_text->SetColor(Gold);
+	new Drawing::Keyhook(settingsTab, GameSettings::KeyHookOffset, y + 2, &filterCycleKey, "");
 	y += 15;
 
 	colored_text = new Texthook(settingsTab, x, y + 2, "Filter Level:");
@@ -740,6 +746,22 @@ void Item::OnLoop() {
 }
 
 void Item::OnKey(bool up, BYTE key, LPARAM lParam, bool* block) {
+	if (key == filterCycleKey) {
+		*block = true;
+		if (!up && D2CLIENT_GetPlayerUnit()) {
+			if (filterLevelSetting == ItemFilterNames.size() - 1) {
+				filterLevelSetting = 0;
+				PrintText(ITEM_QUALITY_NONE, "Filter level: 0 - Show All Items");
+			}
+			else if (filterLevelSetting < ItemFilterNames.size()) {
+				filterLevelSetting++;
+				PrintText(ITEM_QUALITY_NONE, "Filter level: %s", &ItemFilterNames[filterLevelSetting]);
+			}
+			ResetCaches();
+			return;
+		}
+	}
+
 	for (map<string, Toggle>::iterator it = Toggles.begin(); it != Toggles.end(); it++) {
 		if (key == (*it).second.toggle) {
 			*block = true;

--- a/BH/Modules/Item/Item.h
+++ b/BH/Modules/Item/Item.h
@@ -60,7 +60,10 @@ private:
 	unsigned int showPlayer;
 	Drawing::UITab* settingsTab;
 	static unsigned int filterLevelSetting;
-	unsigned int filterCycleKey;
+	static unsigned int prevFilterLevelSetting;
+	unsigned int filterLevelIncKey;
+	unsigned int filterLevelDecKey;
+	unsigned int filterLevelPrevKey;
 public:
 	static UnitAny* viewingUnit;
 	vector<string> ItemFilterNames;
@@ -70,6 +73,7 @@ public:
 	void OnLoad();
 	void OnUnload();
 	void ReplaceItemFilters(vector<string> itemFilterNames);
+	void ChangeFilterLevels(int newLevel);
 
 	void LoadConfig();
 	void DrawSettings();

--- a/BH/Modules/Item/Item.h
+++ b/BH/Modules/Item/Item.h
@@ -60,6 +60,7 @@ private:
 	unsigned int showPlayer;
 	Drawing::UITab* settingsTab;
 	static unsigned int filterLevelSetting;
+	unsigned int filterCycleKey;
 public:
 	static UnitAny* viewingUnit;
 	vector<string> ItemFilterNames;

--- a/BH/Modules/MapNotify/MapNotify.cpp
+++ b/BH/Modules/MapNotify/MapNotify.cpp
@@ -34,7 +34,7 @@ void MapNotify::OnLoad() {
 void MapNotify::OnKey(bool up, BYTE key, LPARAM lParam, bool* block) {
 	GameSettings* settings = static_cast<GameSettings*>(BH::moduleManager->Get("gamesettings"));
 	bool ctrlState = ((GetKeyState(VK_LCONTROL) & 0x80) || (GetKeyState(VK_RCONTROL) & 0x80));
-	if (key == settings->reloadConfigCtrl && ctrlState || key == settings->reloadConfig) {
+	if (key == settings->reloadConfigCtrl && ctrlState || key == settings->reloadConfig && !ctrlState) {
 		*block = true;
 		if (up)
 			BH::ReloadConfig();

--- a/BH/Modules/Party/Party.cpp
+++ b/BH/Modules/Party/Party.cpp
@@ -177,8 +177,9 @@ void Party::OnKey(bool up, BYTE key, LPARAM lParam, bool* block)  {
 		return;
 	}
 
+	bool ctrlState = ((GetKeyState(VK_LCONTROL) & 0x80) || (GetKeyState(VK_RCONTROL) & 0x80));
 	for (map<string,Toggle>::iterator it = Toggles.begin(); it != Toggles.end(); it++) {
-		if (key == (*it).second.toggle) {
+		if (key == (*it).second.toggle && !ctrlState) {
 			*block = true;
 			if (up) {
 				(*it).second.state = !(*it).second.state;

--- a/BH/Modules/ScreenInfo/ScreenInfo.cpp
+++ b/BH/Modules/ScreenInfo/ScreenInfo.cpp
@@ -69,8 +69,9 @@ void ScreenInfo::OnGameJoin() {
 }
 
 void ScreenInfo::OnKey(bool up, BYTE key, LPARAM lParam, bool* block) {
+	bool ctrlState = ((GetKeyState(VK_LCONTROL) & 0x80) || (GetKeyState(VK_RCONTROL) & 0x80));
 	for (map<string, Toggle>::iterator it = Toggles.begin(); it != Toggles.end(); it++) {
-		if (key == (*it).second.toggle) {
+		if (key == (*it).second.toggle && !ctrlState) {
 			*block = true;
 			if (up) {
 				(*it).second.state = !(*it).second.state;

--- a/BH/Modules/StashExport/StashExport.cpp
+++ b/BH/Modules/StashExport/StashExport.cpp
@@ -582,6 +582,7 @@ void StashExport::CopyItemJSONToClipboard() {
 }
 
 void StashExport::OnKey(bool up, BYTE key, LPARAM lParam, bool* block) {
+	bool ctrlState = ((GetKeyState(VK_LCONTROL) & 0x80) || (GetKeyState(VK_RCONTROL) & 0x80));
 	if (key == exportGear) {
 		*block = true;
 		if (up)
@@ -596,14 +597,14 @@ void StashExport::OnKey(bool up, BYTE key, LPARAM lParam, bool* block) {
 		}
 	}
 	// Control + C
-	else if (key == 67 && GetKeyState(VK_CONTROL) & 0x8000) {
+	else if (key == 67 && ctrlState) {
 		*block = true;
 		if (!up)
 			return;
 		CopyItemJSONToClipboard();
 	}
 	for (map<string, Toggle>::iterator it = Toggles.begin(); it != Toggles.end(); it++) {
-		if (key == (*it).second.toggle) {
+		if (key == (*it).second.toggle && !ctrlState) {
 			*block = true;
 			if (up) {
 				(*it).second.state = !(*it).second.state;


### PR DESCRIPTION
Should be a pretty self-explanatory change.

More than happy to adjust for style preferences. For example, I was on the fence about leaving the number in with the text message. Eventually figured it would help prevent ambiguity with level names though.

Defaulting to `Numpad +` to be out of the way, but easily accessed with with the mouse hand.

![filter-cycle-test](https://github.com/Project-Diablo-2/BH/assets/72973313/8a156ff0-60f3-4df0-9cd7-25f24afb03ad)


Also considered/ing separate increment/decrement bindings. At the time of writing, it felt like that would be too many little things from a usage standpoint. Would love either a correction or confirmation on that.