### PR TITLE
Add the "gs:" option to filter strings in the lobby

### DIFF
--- a/BH/BH.vcxproj
+++ b/BH/BH.vcxproj
@@ -183,6 +183,7 @@ powershell.exe -NoProfile -File "$(ProjectDir)..\..\scripts\CopyDataFolder.ps1"<
     <ClCompile Include="Modules\Bnet\Bnet.cpp" />
     <ClCompile Include="Modules\ChatColor\ChatColor.cpp" />
     <ClCompile Include="Modules\Gamefilter\Gamefilter.cpp" />
+    <ClCompile Include="Modules\Gamefilter\ParsedFilterString.cpp" />
     <ClCompile Include="Modules\GameSettings\GameSettings.cpp" />
     <ClCompile Include="Modules\Item\Item.cpp" />
     <ClCompile Include="Modules\Item\ItemDisplay.cpp" />
@@ -234,6 +235,7 @@ powershell.exe -NoProfile -File "$(ProjectDir)..\..\scripts\CopyDataFolder.ps1"<
     <ClInclude Include="Modules\Bnet\Bnet.h" />
     <ClInclude Include="Modules\ChatColor\ChatColor.h" />
     <ClInclude Include="Modules\Gamefilter\Gamefilter.h" />
+    <ClInclude Include="Modules\Gamefilter\ParsedFilterString.h" />
     <ClInclude Include="Modules\GameSettings\GameSettings.h" />
     <ClInclude Include="Modules\Item\Item.h" />
     <ClInclude Include="Modules\Item\ItemDisplay.h" />

--- a/BH/BH.vcxproj.filters
+++ b/BH/BH.vcxproj.filters
@@ -72,6 +72,9 @@
     <ClCompile Include="Modules\Gamefilter\Gamefilter.cpp">
       <Filter>Modules\Gamefilter</Filter>
     </ClCompile>
+    <ClCompile Include="Modules\Gamefilter\ParsedFilterString.cpp">
+      <Filter>Modules\Gamefilter</Filter>
+    </ClCompile>
     <ClCompile Include="Modules\Item\Item.cpp">
       <Filter>Modules\Item</Filter>
     </ClCompile>
@@ -175,6 +178,9 @@
       <Filter>Modules\ChatColor</Filter>
     </ClInclude>
     <ClInclude Include="Modules\Gamefilter\Gamefilter.h">
+      <Filter>Modules\Gamefilter</Filter>
+    </ClInclude>
+    <ClInclude Include="Modules\Gamefilter\ParsedFilterString.h">
       <Filter>Modules\Gamefilter</Filter>
     </ClInclude>
     <ClInclude Include="Modules\Item\Item.h">

--- a/BH/Modules/Gamefilter/Gamefilter.cpp
+++ b/BH/Modules/Gamefilter/Gamefilter.cpp
@@ -1,4 +1,5 @@
 ﻿#include "Gamefilter.h"
+#include "ParsedFilterString.h"
 #include "../../D2Ptrs.h"
 #include "../../D2Intercepts.h"
 #include "../../D2Stubs.h"
@@ -118,16 +119,12 @@ void Gamefilter::OnRealmPacketRecv(BYTE* pPacket, bool* blockPacket) {
 			showDifficulty = App.bnet.showNormalDiff.value;
 		}
 
-		string sGameName;
-
 		for (unsigned int i = 0; i < sFilter.length(); i++)
 			sFilter[i] = ::toupper(sFilter[i]);
-
-		for (unsigned int i = 0; i < pEntry->sGameName.length(); i++)
-			sGameName += ::toupper(pEntry->sGameName[i]);
 		sLastFilter = sFilter;
 
-		if ((wFilter.empty() || strstr(sGameName.c_str(), sFilter.c_str())) && showDifficulty)
+		ParsedFilterString parsedFilter(sFilter.c_str());
+		if (parsedFilter.IsIncluded(pEntry) && showDifficulty)
 		{
 			ControlText* pText = new ControlText;
 			memset(pText, NULL, sizeof(ControlText));
@@ -447,12 +444,8 @@ void Gamefilter::BuildGameList(string sFilter)
 				showDifficulty = App.bnet.showNormalDiff.value;
 			}
 
-			string sGameName((*ListEntry)->sGameName.c_str());
-
-			for (UINT i = 0; i < sGameName.length(); i++)
-				sGameName[i] = ::toupper(sGameName[i]);
-
-			if (strstr(sGameName.c_str(), sFilter.c_str()) && showDifficulty)
+			ParsedFilterString parsedFilter(sFilter.c_str());
+			if (parsedFilter.IsIncluded(*ListEntry) && showDifficulty)
 			{
 
 				ControlText* pText = new ControlText;

--- a/BH/Modules/Gamefilter/ParsedFilterString.cpp
+++ b/BH/Modules/Gamefilter/ParsedFilterString.cpp
@@ -1,0 +1,118 @@
+#include "ParsedFilterString.h"
+#include "GameFilter.h"
+#include <vector>
+#include <map>
+
+static std::string UpperString(const char* begin, const char* end)
+{
+	if (begin >= end)
+		return "";
+	std::string s;
+	s.reserve(end - begin);
+	for (const char* p = begin; p < end; p++)
+		s.push_back(::toupper(*p));
+	return s;
+}
+
+static std::string UpperString(const std::string s) {
+	return UpperString(s.c_str(), s.c_str()+s.size());
+}
+
+bool ParsedFilterString::IsIncluded(const GameListEntry* entry) const
+{
+	if (!servers.empty()) {
+		std::string serverName = std::to_string(entry->gs + 1);
+		if (servers.find(serverName) == servers.end())
+			return false;
+	}
+
+	if (!gameName.empty() && !strstr(UpperString(entry->sGameName).c_str(), gameName.c_str()))
+		return false;
+
+	return true;
+}
+
+ParsedFilterString::ParsedFilterString(const char* filter)
+{
+	ParseNoClear(filter);
+}
+
+void ParsedFilterString::Parse(const char* filter)
+{
+	servers.clear();
+	gameName.clear();
+	ParseNoClear(filter);
+}
+
+void ParsedFilterString::ParseNoClear(const char* filter)
+{
+	if (!filter)
+		return;
+	const char* pEnd = filter;
+
+	// an iteration of this loop processes one of the space separated words of the filter string
+	for (const char* pSpace = pEnd; *pSpace; pSpace = pEnd)
+	{
+		const char* pWord = pSpace;
+		// skipping spaces in front of the word
+		while (*pWord && ::isspace(*pWord))
+			pWord++;
+
+		pEnd = pWord;
+		// skipping to the end of the word
+		while (*pEnd && !::isspace(*pEnd))
+			pEnd++;
+
+		// zero token length - we reached the end of the input string
+		if (pWord == pEnd)
+			break;
+
+		if (TryParseAnyParams(pWord, pEnd))
+			continue;
+
+		if (!gameName.empty())
+			gameName.append(pSpace, pWord);
+		gameName.append(UpperString(pWord, pEnd));
+	}
+}
+
+bool ParsedFilterString::TryParseAnyParams(const char* begin, const char* end)
+{
+	// TODO: if you need additional params like "myparam:p1,p2" in the future then
+	// add a method like ParseGameServerParams and call it from here in a similar way:
+	if (ParseGameServerParams(begin, end))
+		return true;
+	return false;
+}
+
+// ParseParamList tries to parse a string that looks like "ParamPrefix:Param1,Param2,Param3,...".
+// Returns true on success along with the uppercase parameter values in the params vector.
+// The params vector may be empty on return. Empty strings are never pushed into the vector.
+static bool ParseParamList(const char* paramPrefix, const char* begin, const char* end, std::vector<std::string>& params)
+{
+	size_t prefixLen = strlen(paramPrefix);
+	if (prefixLen > size_t(end - begin) || _strnicmp(begin, paramPrefix, prefixLen) != 0)
+		return false;
+
+	for (const char* p = begin + prefixLen; p < end;)
+	{
+		const char* paramBegin = p;
+		while (p < end && *p != L',')
+			p++;
+		if (p > paramBegin)
+			params.push_back(UpperString(paramBegin, p));
+		// skipping the comma, not a problem if we reached the end of the input string
+		p++;
+	}
+	return true;
+}
+
+bool ParsedFilterString::ParseGameServerParams(const char* begin, const char* end)
+{
+	std::vector<std::string> params;
+	if (!ParseParamList("gs:", begin, end, params))
+		return false;
+	for (auto it = params.begin(); it != params.end(); ++it)
+		servers.insert(*it);
+	return true;
+}

--- a/BH/Modules/Gamefilter/ParsedFilterString.h
+++ b/BH/Modules/Gamefilter/ParsedFilterString.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <windows.h>
+#include <set>
+#include <string>
+
+struct GameListEntry;
+
+// ParsedFilterString can tell if a GameList entry matches the game name
+// and any additional (optional) parameters recognized by this parser.
+//
+// "gs:1 baal"         nightmare baal runs on game server 1
+// "trist gs:1,2"      normal trist runs on game servers 1 & 2
+// "gs:1,2"            all games on game servers 1 & 2
+// "bk5"               search all servers on all difficulties for a bk5 ring
+class ParsedFilterString
+{
+public:
+	ParsedFilterString(const char* filter = NULL);
+	void Parse(const char* filter);
+	bool IsIncluded(const GameListEntry* entry) const;
+
+private:
+	void ParseNoClear(const char* filter);
+	bool TryParseAnyParams(const char* begin, const char* end);
+	bool ParseGameServerParams(const char* begin, const char* end);
+
+private:
+	std::set<std::string> servers;		// empty set allows any server (the server names are uppercase)
+	std::string gameName;				// empty string allows any game name (gameName is uppercase)
+};


### PR DESCRIPTION
This feature allows the player to select game servers in the lobby with filter strings like `gs:1,2 baal`.

I haven't tested this change because the README.md of this repo advises against it:

> Any debug or changed version will only work in Single Player. Do not enter multiplayer with a modified BH

The bulk of the logic (the `ParsedFilterString` class) was implemented in a small standalone project where I tested it manually so that shouldn't be extremely buggy. You have to make sure that the untested changes (in the `GameFilter` class) work as intended when the game goes online and enters the lobby.
