### PR TITLE
Correct filter name strings once and for all

### DIFF
--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -722,7 +722,7 @@ void Item::ChangeFilterLevels(int newLevel) {
 	if (filterLevelSetting == 0)
 		PrintText(TextColor::Gold, "Filter level: ÿc50 - Show All Items");
 	else
-		PrintText(TextColor::Gold, "Filter level: ÿc0%s", ItemFilterNames[filterLevelSetting]);
+		PrintText(TextColor::Gold, "Filter level: ÿc0%s", ItemFilterNames[filterLevelSetting].c_str());
 
 	ResetCaches();
 }


### PR DESCRIPTION
I don't know where in the line this either broke or worked inexplicably.
Things function properly without this as long as the filter names are at least 12 characters long, anything shorter displays an empty name.

While less important: It also apparently fixes crashes in WINE (they weren't happening during the S8 beta, so I'm not 100% sure this is where that crash was coming from).