### PR TITLE
Allow `%NL%` within shops

### DIFF
--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1017,7 +1017,10 @@ void SubstituteNameVariables(UnitItemInfo* uInfo,
 	sprintf_s(rangeadder, "%d", txt->brangeadder);
 	sprintf_s(qty, "%d", D2COMMON_GetUnitStat(item, STAT_AMMOQUANTITY, 0));
 
-	bool inShop = (find(begin(ShopNPCs), end(ShopNPCs), uInfo->item->pItemData->pOwnerInventory->pOwner->dwTxtFileNo) == end(ShopNPCs)) ? false : true;
+	bool inShop = false;
+	if (item->pItemData->pOwnerInventory != 0 && // Skip on ground items
+		find(begin(ShopNPCs), end(ShopNPCs), item->pItemData->pOwnerInventory->pOwner->dwTxtFileNo) != end(ShopNPCs))
+		inShop = true;
 
 	UnitAny* pUnit = D2CLIENT_GetPlayerUnit();
 	if (pUnit && txt->bquest == 0) { sprintf_s(sellValue, "%d", D2COMMON_GetItemPrice(pUnit, item, D2CLIENT_GetDifficulty(), (DWORD)D2CLIENT_GetQuestInfo(), 0x201, 1)); }

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -785,6 +785,25 @@ std::string join(C const& strings,
 	return ostr.str();
 }
 
+int ShopNPCs[] = {
+	NPCID_Akara,	// Act 1
+	NPCID_Gheed,	// Act 1
+	NPCID_Charsi,	// Act 1
+	NPCID_Elzix,	// Act 2
+	NPCID_Drognan,	// Act 2
+	NPCID_Fara,		// Act 2
+	NPCID_Lysander,	// Act 2
+	NPCID_Hratli,	// Act 3
+	NPCID_Alkor,	// Act 3
+	NPCID_Ormus,	// Act 3
+	NPCID_Asheara,	// Act 3
+	NPCID_Jamella,	// Act 4
+	NPCID_Halbu,	// Act 4
+	NPCID_Larzuk,	// Act 5
+	NPCID_Malah,	// Act 5
+	NPCID_Anya		// Act 5
+};
+
 char* GemLevels[] = {
 	"NONE",
 	"Chipped",
@@ -1041,9 +1060,10 @@ void SubstituteNameVariables(UnitItemInfo* uInfo,
 		{
 			if (bLimit && replacements[n].key == "NL")
 			{
-				// Allow %NL% on identified, magic+ item names
+				// Allow %NL% on identified, magic+ item names, and items within shops
 				if ((uInfo->item->pItemData->dwFlags & ITEM_IDENTIFIED) > 0 &&
-					(uInfo->item->pItemData->dwQuality >= ITEM_QUALITY_MAGIC || (uInfo->item->pItemData->dwFlags & ITEM_RUNEWORD) > 0))
+					(uInfo->item->pItemData->dwQuality >= ITEM_QUALITY_MAGIC || (uInfo->item->pItemData->dwFlags & ITEM_RUNEWORD) > 0) ||
+					find(begin(ShopNPCs), end(ShopNPCs), uInfo->item->pItemData->pOwnerInventory->pOwner->dwTxtFileNo) != end(ShopNPCs))
 				{
 					name.replace(name.find("%" + replacements[n].key + "%"), replacements[n].key.length() + 2, replacements[n].value);
 				}
@@ -2571,22 +2591,7 @@ bool ShopCondition::EvaluateInternal(UnitItemInfo* uInfo,
 		uInfo->item->pItemData->pOwnerInventory->pOwner)
 	{
 		auto wNpcId = uInfo->item->pItemData->pOwnerInventory->pOwner->dwTxtFileNo;
-		if (wNpcId == NPCID_Akara	||	// Act 1
-			wNpcId == NPCID_Gheed	||	// Act 1
-			wNpcId == NPCID_Charsi	||	// Act 1
-			wNpcId == NPCID_Elzix	||	// Act 2
-			wNpcId == NPCID_Drognan	||	// Act 2
-			wNpcId == NPCID_Fara	||	// Act 2
-			wNpcId == NPCID_Lysander ||	// Act 2
-			wNpcId == NPCID_Hratli	||	// Act 3
-			wNpcId == NPCID_Akara	||	// Act 3
-			wNpcId == NPCID_Ormus	||	// Act 3
-			wNpcId == NPCID_Asheara	||	// Act 3
-			wNpcId == NPCID_Jamella	||	// Act 4
-			wNpcId == NPCID_Halbu	||	// Act 4
-			wNpcId == NPCID_Larzuk	||	// Act 5
-			wNpcId == NPCID_Malah	||	// Act 5
-			wNpcId == NPCID_Anya)		// Act 5
+		if (find(begin(ShopNPCs), end(ShopNPCs), wNpcId) != end(ShopNPCs))
 		{
 			is_shop = true;
 		}


### PR DESCRIPTION
Mentioned a few times within the lootfilter channel on Discord.

The primary use seems like it would be for a "revealed" version of gambling in a less eyesore manner.
Woflie referred me to the discussion way back on `%NL%` being disabled for reasons. This doesn't seem as though it would really be subject to the same issue, but if that's not true, just say the word and it'll go away.


Positive side-effect: Adds Alkor to the `SHOP` condition. Currently Akara has his spot stolen and is used twice. Not that anyone ever goes there, but...yeah.


Edit: While functional, this is still subject to name length limits. I'd like to include an exclusion to shops for said limit (or at least extend it), but would also like input on that. ~~If it's deemed reasonable, I can push a commit that I have ready for that.~~ I could see this having use beyond just the gambling screen. Most notably filter-made information on items from Akara (brief README style). I could also see the argument of this being abused in some way for some reason.

<details>
<summary>Ideal scenario, example courtesy of Wolfie:</summary>

![image](https://github.com/Project-Diablo-2/BH/assets/72973313/41b78b42-4126-4f9a-b5fb-3de283abe944)

</details>

Edit 2: I went ahead and pushed that limit increase. A little less processing involved with the implementation, and I can adjust the change based on feedback. I used an arbitrary 500 character limit which still seems like overkill to me, and was chosen only because of the gambling use case for amulets coming out to ~400 characters if done "formally."