### PR TITLE
several small ItemDisplay improvements

### DIFF
--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -892,6 +892,8 @@ string ItemNameLookupCache::make_cached_T(UnitItemInfo* uInfo,
 	const string& name)
 {
 	string new_name(name);
+	if (new_name.front() == ' ') { new_name.erase(0, 1); }					// removes one leading space (happens on magic items without a prefix)
+	if (new_name.back() == ' ') { new_name.erase(new_name.size() - 1, 1); }	// removes one trailing space (happens on magic items without a suffix)
 	for (vector<Rule*>::const_iterator it = RuleList.begin(); it != RuleList.end(); it++)
 	{
 		if ((*it)->Evaluate(uInfo))
@@ -1050,11 +1052,14 @@ void SubstituteNameVariables(UnitItemInfo* uInfo,
 		{ "WPNSPD", wpnspd },
 		{ "RANGE", rangeadder },
 		{ "CODE", code },
+		{ "CL", "\n" },
 		{ "NL", "\n" },
 		{ "PRICE", sellValue },
 		{ "QTY", qty },
 		{ "RES", allres},
 		{ "ED", ed},
+		{ "LBRACE", "{" },
+		{ "RBRACE", "}" },
 		COLOR_REPLACEMENTS
 	};
 	int nColorCodesSize = 0;
@@ -1063,9 +1068,9 @@ void SubstituteNameVariables(UnitItemInfo* uInfo,
 	{
 		while (name.find("%" + replacements[n].key + "%") != string::npos)
 		{
-			if (bLimit && replacements[n].key == "NL")
+			if (bLimit && (replacements[n].key == "NL" || replacements[n].key == "CL"))
 			{
-				// Allow %NL% on identified, magic+ item names, and items within shops
+				// Allow %NL% and %CL% on identified, magic+ item names, and items within shops
 				if ((uInfo->item->pItemData->dwFlags & ITEM_IDENTIFIED) > 0 &&
 					(uInfo->item->pItemData->dwQuality >= ITEM_QUALITY_MAGIC || (uInfo->item->pItemData->dwFlags & ITEM_RUNEWORD) > 0) ||
 					inShop)
@@ -1083,7 +1088,14 @@ void SubstituteNameVariables(UnitItemInfo* uInfo,
 				name.replace(name.find("%" + replacements[n].key + "%"), replacements[n].key.length() + 2, replacements[n].value);
 			}
 		}
+		// Remove leading or trailing new lines from %CL% keywords
+		if (replacements[n].key == "CL")
+		{
+			if (name.front() == '\n') { name.erase(0, 1); }
+			if (name.back() == '\n') { name.erase(name.size() - 1, 1); }
+		}
 	}
+
 	// Replace named stat output strings with their STAT# counterpart
 	map<string, int>::iterator it;
 	for (it = stat_id_map.begin(); it != stat_id_map.end(); it++)
@@ -2584,7 +2596,8 @@ bool EquippedCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	bool is_equipped = false;
 	if (uInfo->item->pItemData->pOwnerInventory)
 	{
-		if (uInfo->item->pItemData->pOwnerInventory->dwOwnerId == D2CLIENT_GetPlayerUnit()->dwUnitId)
+		if (uInfo->item->pItemData->pOwnerInventory->dwOwnerId == D2CLIENT_GetPlayerUnit()->dwUnitId || 
+			uInfo->item->pItemData->pOwnerInventory->dwOwnerId == D2CLIENT_GetMercUnit()->dwUnitId)
 		{
 			if (uInfo->item->pItemData->BodyLocation > 0 && uInfo->item->pItemData->ItemLocation == STORAGE_NULL)
 			{

--- a/BH/Modules/MapNotify/MapNotify.cpp
+++ b/BH/Modules/MapNotify/MapNotify.cpp
@@ -83,7 +83,35 @@ void MapNotify::OnDraw() {
 								&& (*BH::MiscToggles2)["Item Detailed Notifications"].state) {
 								if ((*BH::MiscToggles2)["Item Close Notifications"].state || (dwFlags & ITEM_NEW)) {
 									std::string itemName = GetItemName(unit);
+									
+									// Removes leading/trailing spaces from text notifications (this doesn't affect the trailing spaces that are due to color keywords)
+									bool finished = false;
 									size_t start_pos = 0;
+									while (!finished && start_pos < itemName.size() - 3)
+									{
+										if (itemName.at(start_pos) == ' ') { itemName.erase(start_pos, 1); }				// removes leading spaces
+										else if (itemName.at(start_pos) == 'ÿ' && itemName.at(start_pos + 1) == 'c')
+										{
+											char x = itemName.at(start_pos + 2);
+											if (x == '0' || x == '1' || x == '2' || x == '3' || x == '4' || x == '5' || x == '6' || x == '7' || x == '8' || x == '9' || x == ';' || x == ':') { start_pos += 3; }	// skips over (most) color codes
+										}
+										else { finished = true; }
+									}
+									finished = false;
+									start_pos = itemName.size() - 1;
+									while (!finished && start_pos > 2)
+									{
+										if (itemName.at(start_pos) == ' ') { itemName.erase(start_pos, 1); start_pos--; }	// removes trailing spaces
+										else if (itemName.at(start_pos - 2) == 'ÿ' && itemName.at(start_pos - 1) == 'c')
+										{
+											char x = itemName.at(start_pos);
+											if (x == '0' || x == '1' || x == '2' || x == '3' || x == '4' || x == '5' || x == '6' || x == '7' || x == '8' || x == '9' || x == ';' || x == ':') { start_pos -= 3; }	// skips over (most) color codes
+										}
+										else { finished = true; }
+									}
+									// TODO: Prevent color keywords from increasing the size of the text box for the displayed string (each color keyword increases the size of the string by 3, which also increases the size of the text box by the same amount even though the color keywords aren't actually displayed themselves)
+									
+									start_pos = 0;
 									while ((start_pos = itemName.find('\n', start_pos)) != std::string::npos) {
 										itemName.replace(start_pos, 1, " - ");
 										start_pos += 3;

--- a/BH/Modules/MapNotify/MapNotify.cpp
+++ b/BH/Modules/MapNotify/MapNotify.cpp
@@ -83,35 +83,9 @@ void MapNotify::OnDraw() {
 								&& (*BH::MiscToggles2)["Item Detailed Notifications"].state) {
 								if ((*BH::MiscToggles2)["Item Close Notifications"].state || (dwFlags & ITEM_NEW)) {
 									std::string itemName = GetItemName(unit);
-									
-									// Removes leading/trailing spaces from text notifications (this doesn't affect the trailing spaces that are due to color keywords)
-									bool finished = false;
+									regex trimName("^\\s*(?:(?:\\s*?)(ÿc[0123456789;:]))*\\s*(.*?\\S)\\s*(?:ÿc[0123456789;:])*\\s*$");	// Matches on leading/trailing spaces (skips most color codes)
+									itemName = regex_replace(itemName, trimName, "$1$2");												// Trims the matched spaces from notifications
 									size_t start_pos = 0;
-									while (!finished && start_pos < itemName.size() - 3)
-									{
-										if (itemName.at(start_pos) == ' ') { itemName.erase(start_pos, 1); }				// removes leading spaces
-										else if (itemName.at(start_pos) == 'ÿ' && itemName.at(start_pos + 1) == 'c')
-										{
-											char x = itemName.at(start_pos + 2);
-											if (x == '0' || x == '1' || x == '2' || x == '3' || x == '4' || x == '5' || x == '6' || x == '7' || x == '8' || x == '9' || x == ';' || x == ':') { start_pos += 3; }	// skips over (most) color codes
-										}
-										else { finished = true; }
-									}
-									finished = false;
-									start_pos = itemName.size() - 1;
-									while (!finished && start_pos > 2)
-									{
-										if (itemName.at(start_pos) == ' ') { itemName.erase(start_pos, 1); start_pos--; }	// removes trailing spaces
-										else if (itemName.at(start_pos - 2) == 'ÿ' && itemName.at(start_pos - 1) == 'c')
-										{
-											char x = itemName.at(start_pos);
-											if (x == '0' || x == '1' || x == '2' || x == '3' || x == '4' || x == '5' || x == '6' || x == '7' || x == '8' || x == '9' || x == ';' || x == ':') { start_pos -= 3; }	// skips over (most) color codes
-										}
-										else { finished = true; }
-									}
-									// TODO: Prevent color keywords from increasing the size of the text box for the displayed string (each color keyword increases the size of the string by 3, which also increases the size of the text box by the same amount even though the color keywords aren't actually displayed themselves)
-									
-									start_pos = 0;
 									while ((start_pos = itemName.find('\n', start_pos)) != std::string::npos) {
 										itemName.replace(start_pos, 1, " - ");
 										start_pos += 3;


### PR DESCRIPTION
* new %CL% keyword (short for "conditional line") which works the same as %NL% except is ignored if it's the first or last part of a name/description
* new %LBRACE% and %RBRACE% keywords for "{" and "}" symbols so they can be used in descriptions
* EQUIPPED now applies to equipped mercenary items too
* Removed extra trailing/leading space from magic items that didn't have both a prefix and suffix
* Removed some leading/trailing blank spaces for text notifications (all of them except for 3 trailing spaces per color keyword)