### PR TITLE
Allow ESC to close the BH settings window

### DIFF
--- a/BH/Drawing/UI/UI.cpp
+++ b/BH/Drawing/UI/UI.cpp
@@ -263,7 +263,7 @@ bool UI::OnLeftClick(bool up, unsigned int mouseX, unsigned int mouseY) {
 			SetDragged(false, true);
 			if( startX == mouseX && startY == mouseY && GetAsyncKeyState(VK_CONTROL) )
 			{
-				PrintText(135, "Right Click to Close" );
+				PrintText(135, "Right Click or ESC to Close" );
 			}
 		}
 		SetActive(true);

--- a/BH/Modules/GameSettings/GameSettings.cpp
+++ b/BH/Modules/GameSettings/GameSettings.cpp
@@ -257,4 +257,12 @@ void GameSettings::OnKey(bool up, BYTE key, LPARAM lParam, bool* block) {
 			return;
 		}
 	}
+
+	if (!BH::settingsUI->IsMinimized() && key == VK_ESCAPE) {
+		*block = true;
+		if (up)
+			return;
+		BH::settingsUI->SetMinimized(true);
+		return;
+	}
 }


### PR DESCRIPTION
This has been one of those little things that's seemed unreasonably unintuitive, but never really bothersome enough to do anything about. I just happened to be moving things around and thought about it.