### PR TITLE
Fix blank items names when traveling through portal/waypoint

### DIFF
--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -2341,9 +2341,19 @@ bool MapIdCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	Condition* arg1,
 	Condition* arg2)
 {
-	int map_id = (int)D2CLIENT_GetPlayerUnit()->pAct->pRoom1->pRoom2->pLevel->dwLevelNo;
+	UnitAny* player = D2CLIENT_GetPlayerUnit();
 
-	return IntegerCompare(map_id, operation, mapId, mapId2);
+	if (player &&
+		player->pAct &&
+		player->pAct->pRoom1 &&
+		player->pAct->pRoom1->pRoom2 &&
+		player->pAct->pRoom1->pRoom2->pLevel &&
+		player->pAct->pRoom1->pRoom2->pLevel->dwLevelNo > 0)
+	{
+		int map_id = (int)player->pAct->pRoom1->pRoom2->pLevel->dwLevelNo;
+		return IntegerCompare(map_id, operation, mapId, mapId2);
+	}
+	return 0;
 }
 
 bool MapTierCondition::EvaluateInternal(UnitItemInfo* uInfo,

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -2341,7 +2341,7 @@ bool MapIdCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	Condition* arg1,
 	Condition* arg2)
 {
-	auto map_id = **Var_D2CLIENT_MapId();
+	int map_id = (int)D2CLIENT_GetPlayerUnit()->pAct->pRoom1->pRoom2->pLevel->dwLevelNo;
 
 	return IntegerCompare(map_id, operation, mapId, mapId2);
 }

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -2353,7 +2353,7 @@ bool MapIdCondition::EvaluateInternal(UnitItemInfo* uInfo,
 		int map_id = (int)player->pAct->pRoom1->pRoom2->pLevel->dwLevelNo;
 		return IntegerCompare(map_id, operation, mapId, mapId2);
 	}
-	return 0;
+	return false;
 }
 
 bool MapTierCondition::EvaluateInternal(UnitItemInfo* uInfo,


### PR DESCRIPTION
The map ID that's used currently isn't updated before items are displayed, which sometimes results in `MAPID`-using rules matching erroneously (particularly when using portals/waypoints). With most filters' implementations of the condition, this gave the item an actual name and therefore the invisible flag wasn't being applied. This combined with the name being cached as empty caused the now-visible item to have an empty nameplate.

While I'll fully admit that I don't know *why* the multiple methods of getting a map ID exist simultaneously, this switch *does* seem to update on time, so I won't ask too many questions.