### PR TITLE
Replace RPN evaluation with tree

### DIFF
--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1454,7 +1454,6 @@ Rule::Rule(vector<Condition*>& inputConditions,
 {
 	Condition::ProcessConditions(inputConditions, conditions);
 	BuildAction(str, &action);
-	conditionStack.reserve(conditions.size()); // TODO: too large?
 	if (!Convert()) {
 		root = -1;
 	}


### PR DESCRIPTION
This is roughly a 1.4-2.6x speed-up. Filters tested:

* eqN
* Hiim
* Kassahi
* Kryszard

Added a circuit type to the base condition as `dynamic_cast` caused higher peak evaluation times.

Note: the old RPN evaluation had a bug where the first and second arguments were reversed. Reversing these parameters increased performance.