### PR TITLE
Refactor %NL% and %CL% processing

### DIFF
--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -948,7 +948,8 @@ void GetItemName(UnitItemInfo* uInfo,
 void SubstituteNameVariables(UnitItemInfo* uInfo,
 	string& name,
 	const string& action_name,
-	BOOL          bLimit);
+	BOOL          bLimit,
+	BOOL          last_rule);
 void ReplaceStatSkillVars(UnitItemInfo* uInfo, string& name);
 string NameVarSockets(UnitItemInfo* uInfo);
 string NameVarRuneNum(UnitItemInfo* uInfo);


### PR DESCRIPTION
I *believe* this should result in the desired effects of `%CL%`. There seems to be some uncertainty with some of the details between different creators in that regard.

With this implementation:
* Leading and trailing `%CL%`s **_after all rules have been processed_** will be trimmed.
* Conjoined `%CL%`s will be treated as a single `%CL%`. (This is a point which I may have interpreted wrong.)
* Remaining `%CL%`s will act as `%NL%` and add a new line where allowed.



This also includes a fix to skill/stat/multi/etc variables being replaced early if they're preceded by a basic replace variable without separation.