### PR TITLE
Hotfixes for S9 CB patch #3

### DIFF
--- a/BH/D2Ptrs.h
+++ b/BH/D2Ptrs.h
@@ -408,6 +408,7 @@ FUNCPTR(D2COMMON, 10630_GetHighestLevelSkillFromUnitAndId, Skill* __fastcall, (U
 FUNCPTR(D2COMMON, 10806_DATATBLS_GetGemsTxtRecord, D2GemsTxt* __stdcall, (int nGemId), -10806);
 FUNCPTR(D2COMMON, 10832_CalcDM56, int __stdcall, (int nSkillLevel, int nSkillId), -10832);
 FUNCPTR(D2COMMON, 10865_HasDurability, int __stdcall, (UnitAny* pItem), -10865);
+FUNCPTR(D2COMMON, 10957_GetStaffMods, int __stdcall, (UnitAny* pItem), -10957);
 FUNCPTR(D2COMMON, 11015_GetItemLevelRequirement, int __stdcall, (UnitAny* pItem, UnitAny* pUnit), -11015);
 FUNCPTR(D2COMMON, 11116_GetMaxDurabilityFromUnit, int __stdcall, (UnitAny* pItem), -11116);
 FUNCPTR(D2COMMON, 11144_GetQuiverType, int __stdcall, (UnitAny* pItem), -11144);

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -850,6 +850,7 @@ int CreateUnitItemInfo(UnitItemInfo* uInfo, UnitAny* item) {
 	uInfo->item = item;
 	if (ItemAttributeMap.find(std::string(uInfo->itemCode)) != ItemAttributeMap.end()) {
 		uInfo->attrs = ItemAttributeMap[std::string(uInfo->itemCode)];
+		uInfo->attrs->staffmodClass = D2COMMON_10957_GetStaffMods(uInfo->item);
 		return 0;
 	}
 	else {

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -296,6 +296,11 @@ void GetWeaponAttributes()
 	for (auto d = 0; d < pItemDataTables->nWeaponsTxtRecordCount; d++)
 	{
 		ItemsTxt* pWeapons = &pItemDataTables->pWeapons[d];
+		D2ItemTypesTxt* pItemTypesTxtRecord = NULL;
+		if (pWeapons->nType >= 0 && pWeapons->nType < pItemDataTables->nItemsTxtRecordCount)
+		{
+			pItemTypesTxtRecord = &(*p_D2COMMON_sgptDataTable)->pItemsTypeTxt[pWeapons->nType];
+		}
 		BYTE stackable = pWeapons->bstackable > 0 ? pWeapons->bstackable : 0;
 		BYTE useable = pWeapons->buseable > 0 ? pWeapons->buseable : 0;
 		BYTE throwable = throwableMap[pWeapons->nType] > 0 ? throwableMap[pWeapons->nType] : 0;
@@ -401,6 +406,7 @@ void GetWeaponAttributes()
 		attrs->miscFlags = 0;
 		attrs->qualityLevel = pWeapons->blevel;
 		attrs->magicLevel = pWeapons->bmagiclvl;
+		attrs->staffmodClass = pItemTypesTxtRecord ? pItemTypesTxtRecord->nStaffMods : 255;
 		ItemAttributeMap[GetTxtItemCode(pWeapons)] = attrs;
 	}
 }
@@ -411,6 +417,11 @@ void GetArmorAttributes()
 	for (auto d = 0; d < pItemDataTables->nArmorTxtRecordCount; d++)
 	{
 		ItemsTxt* pArmor = &pItemDataTables->pArmor[d];
+		D2ItemTypesTxt* pItemTypesTxtRecord = NULL;
+		if (pArmor->nType >= 0 && pArmor->nType < pItemDataTables->nItemsTxtRecordCount)
+		{
+			pItemTypesTxtRecord = &(*p_D2COMMON_sgptDataTable)->pItemsTypeTxt[pArmor->nType];
+		}
 		BYTE stackable = pArmor->bstackable > 0 ? pArmor->bstackable : 0;
 		BYTE useable = pArmor->buseable > 0 ? pArmor->buseable : 0;
 		BYTE throwable = throwableMap[pArmor->nType] > 0 ? throwableMap[pArmor->nType] : 0; // Hey, you never know
@@ -481,6 +492,7 @@ void GetArmorAttributes()
 		attrs->miscFlags = 0;
 		attrs->qualityLevel = pArmor->blevel;
 		attrs->magicLevel = pArmor->bmagiclvl;
+		attrs->staffmodClass = pItemTypesTxtRecord ? pItemTypesTxtRecord->nStaffMods : 255;
 		ItemAttributeMap[GetTxtItemCode(pArmor)] = attrs;
 	}
 }
@@ -491,6 +503,11 @@ void GetMiscAttributes()
 	for (auto d = 0; d < pItemDataTables->nMiscTxtRecordCount; d++)
 	{
 		ItemsTxt* pMisc = &pItemDataTables->pMisc[d];
+		D2ItemTypesTxt* pItemTypesTxtRecord = NULL;
+		if (pMisc->nType >= 0 && pMisc->nType < pItemDataTables->nItemsTxtRecordCount)
+		{
+			pItemTypesTxtRecord = &(*p_D2COMMON_sgptDataTable)->pItemsTypeTxt[pMisc->nType];
+		}
 		BYTE stackable = pMisc->bstackable > 0 ? pMisc->bstackable : 0;
 		BYTE useable = pMisc->buseable > 0 ? pMisc->buseable : 0;
 		BYTE throwable = throwableMap[pMisc->nType] > 0 ? throwableMap[pMisc->nType] : 0;
@@ -572,6 +589,7 @@ void GetMiscAttributes()
 		attrs->miscFlags = miscFlags;
 		attrs->qualityLevel = pMisc->blevel;
 		attrs->magicLevel = 0;
+		attrs->staffmodClass = pItemTypesTxtRecord ? pItemTypesTxtRecord->nStaffMods : 255;
 		ItemAttributeMap[GetTxtItemCode(pMisc)] = attrs;
 	}
 }
@@ -850,7 +868,6 @@ int CreateUnitItemInfo(UnitItemInfo* uInfo, UnitAny* item) {
 	uInfo->item = item;
 	if (ItemAttributeMap.find(std::string(uInfo->itemCode)) != ItemAttributeMap.end()) {
 		uInfo->attrs = ItemAttributeMap[std::string(uInfo->itemCode)];
-		uInfo->attrs->staffmodClass = D2COMMON_10957_GetStaffMods(uInfo->item);
 		return 0;
 	}
 	else {

--- a/BH/Modules/Item/Item.h
+++ b/BH/Modules/Item/Item.h
@@ -143,6 +143,7 @@ struct ItemAttributes {
 	unsigned int miscFlags;
 	BYTE qualityLevel;
 	BYTE magicLevel;
+	BYTE staffmodClass;
 };
 
 // Properties from ItemStatCost.txt

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1337,6 +1337,10 @@ void SubstituteNameVariables(UnitItemInfo* uInfo,
 					 (uInfo->item->pItemData->dwQuality >= ITEM_QUALITY_MAGIC || (uInfo->item->pItemData->dwFlags & ITEM_RUNEWORD) > 0)) ||
 					 inShop;
 
+	// Check if non-mag item capable of having staffmods
+	bool nmagStaffmod = ((uInfo->item->pItemData->dwQuality == ITEM_QUALITY_NORMAL || uInfo->item->pItemData->dwQuality == ITEM_QUALITY_SUPERIOR) &&
+						uInfo->attrs->staffmodClass < CLASS_NA);
+
 	if (!name.empty() && (!bLimit || nlAllowed))
 	{
 		// Replace allowed %CL%s with unused character to avoid limit breaches
@@ -1345,6 +1349,18 @@ void SubstituteNameVariables(UnitItemInfo* uInfo,
 		// Replace allowed %NL%s with new lines
 		while (name.find("%NL%") != string::npos)
 			name.replace(name.find("%NL%"), 4, "\n");
+	}
+	else if (!name.empty() && nmagStaffmod)
+	{
+		// Replace first new line and remove all others
+		if (name.find("%NL%") != string::npos && name.find("\n") == string::npos)
+			name.replace(name.find("%NL%"), 4, "\n");
+		if (name.find("%CL%") != string::npos && name.find("\n") == string::npos)
+			name.replace(name.find("%CL%"), 4, "\n");
+		while (name.find("%NL%") != string::npos)
+			name.replace(name.find("%NL%"), 4, "");
+		while (name.find("%CL%") != string::npos)
+			name.replace(name.find("%CL%"), 4, "");
 	}
 	else
 	{

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1338,7 +1338,9 @@ void SubstituteNameVariables(UnitItemInfo* uInfo,
 					 inShop;
 
 	// Check if non-mag item capable of having staffmods
-	bool nmagStaffmod = ((uInfo->item->pItemData->dwQuality == ITEM_QUALITY_NORMAL || uInfo->item->pItemData->dwQuality == ITEM_QUALITY_SUPERIOR) &&
+	bool nmagStaffmod = ((uInfo->item->pItemData->dwQuality == ITEM_QUALITY_INFERIOR ||
+		                  uInfo->item->pItemData->dwQuality == ITEM_QUALITY_NORMAL || 
+		                  uInfo->item->pItemData->dwQuality == ITEM_QUALITY_SUPERIOR) &&
 						uInfo->attrs->staffmodClass < CLASS_NA);
 
 	if (!name.empty() && (!bLimit || nlAllowed))

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -851,9 +851,23 @@ string ItemDescLookupCache::make_cached_T(UnitItemInfo* uInfo)
 	{
 		if ((*it)->Evaluate(uInfo))
 		{
-			SubstituteNameVariables(uInfo, new_name, (*it)->action.description, FALSE, (*it)->action.stopProcessing);
+			SubstituteNameVariables(uInfo, new_name, (*it)->action.description, FALSE);
 			if ((*it)->action.stopProcessing) { break; }
 		}
+	}
+	if (!new_name.empty())
+	{
+		// Collapse paired CLs
+		while (new_name.find("\r\r") != string::npos)
+			new_name.replace(new_name.find("\r\r"), 2, "\r");
+		// Delete leading/trailing CLs
+		if (new_name.find("\r") == 0)
+			new_name.erase(0, 1);
+		if (new_name.rfind("\r") == new_name.size() - 1)
+			new_name.resize(new_name.size() - 1);
+		// Convert to new line
+		while (new_name.find("\r") != string::npos)
+			new_name.replace(new_name.find("\r"), 1, "\n");
 	}
 	return new_name;
 }
@@ -881,9 +895,23 @@ string ItemNameLookupCache::make_cached_T(UnitItemInfo* uInfo,
 	{
 		if ((*it)->Evaluate(uInfo))
 		{
-			SubstituteNameVariables(uInfo, new_name, (*it)->action.name, TRUE, (*it)->action.stopProcessing);
+			SubstituteNameVariables(uInfo, new_name, (*it)->action.name, TRUE);
 			if ((*it)->action.stopProcessing) { break; }
 		}
+	}
+	if (!new_name.empty())
+	{
+		// Collapse paired CLs
+		while (new_name.find("\r\r") != string::npos)
+			new_name.replace(new_name.find("\r\r"), 2, "\r");
+		// Delete leading/trailing CLs
+		if (new_name.find("\r") == 0)
+			new_name.erase(0, 1);
+		if (new_name.rfind("\r") == new_name.size() - 1)
+			new_name.resize(new_name.size() - 1);
+		// Convert to new line
+		while (new_name.find("\r") != string::npos)
+			new_name.replace(new_name.find("\r"), 1, "\n");
 	}
 	return new_name;
 }
@@ -1263,8 +1291,7 @@ void ReplaceStatSkillVars(UnitItemInfo* uInfo,
 void SubstituteNameVariables(UnitItemInfo* uInfo,
 	string& name,
 	const string& action_name,
-	BOOL          bLimit,
-    BOOL          last_rule)
+	BOOL          bLimit)
 {
 	char origName[MAX_ITEM_TEXT_SIZE];
 	sprintf_s(origName, "%s", name.c_str());
@@ -1332,10 +1359,9 @@ void SubstituteNameVariables(UnitItemInfo* uInfo,
 	// TODO: Unify handling of numbered and non-numbered variables
 	ReplaceStatSkillVars(uInfo, name);
 
-	bool nlAllowed = (uInfo->item->pItemData->dwFlags & ITEM_IDENTIFIED) > 0  &&
-					 (uInfo->item->pItemData->dwQuality >= ITEM_QUALITY_MAGIC ||
-					  (uInfo->item->pItemData->dwFlags & ITEM_RUNEWORD) > 0   ||
-					  inShop);
+	bool nlAllowed = ((uInfo->item->pItemData->dwFlags & ITEM_IDENTIFIED) > 0  &&
+					 (uInfo->item->pItemData->dwQuality >= ITEM_QUALITY_MAGIC || (uInfo->item->pItemData->dwFlags & ITEM_RUNEWORD) > 0)) ||
+					 inShop;
 
 	if (!name.empty() && (!bLimit || nlAllowed))
 	{
@@ -1345,21 +1371,6 @@ void SubstituteNameVariables(UnitItemInfo* uInfo,
 		// Replace allowed %NL%s with new lines
 		while (name.find("%NL%") != string::npos)
 			name.replace(name.find("%NL%"), 4, "\n");
-
-		if (last_rule)
-		{
-			// Collapse paired CLs
-			while (name.find("\r\r") != string::npos)
-				name.replace(name.find("\r\r"), 2, "\r");
-			// Delete leading/trailing CLs
-			if (name.find("\r") == 0)
-				name.erase(0, 1);
-			if (name.rfind("\r") == name.size() - 1)
-				name.resize(name.size() - 1);
-			// Convert to new line
-			while (name.find("\r") != string::npos)
-				name.replace(name.find("\r"), 1, "\n");
-		}
 	}
 	else
 	{

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1116,13 +1116,12 @@ void ReplaceStatSkillVars(UnitItemInfo* uInfo,
 	char statVal[16] = "0";
 
 	// Replace named stat output strings with their STAT# counterpart
-	// Matching the prefixed % symbol to avoid intercepting matches from non-numbered variables
 	std::vector<pair<string, int>>::iterator it;
 	for (it = stat_id_map.begin(); it != stat_id_map.end(); it++)
 	{
-		while (name.find("%" + it->first) != string::npos)
+		while (name.find("%" + it->first + "%") != string::npos)
 		{
-			name.replace(name.find("%" + it->first), it->first.length() + 1, "%STAT" + std::to_string(it->second));
+			name.replace(name.find("%" + it->first + "%"), it->first.length() + 2, "%STAT" + std::to_string(it->second) + "%");
 		}
 	}
 

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -948,8 +948,7 @@ void GetItemName(UnitItemInfo* uInfo,
 void SubstituteNameVariables(UnitItemInfo* uInfo,
 	string& name,
 	const string& action_name,
-	BOOL          bLimit,
-	BOOL          last_rule);
+	BOOL          bLimit);
 void ReplaceStatSkillVars(UnitItemInfo* uInfo, string& name);
 string NameVarSockets(UnitItemInfo* uInfo);
 string NameVarRuneNum(UnitItemInfo* uInfo);

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -945,6 +945,9 @@ inline bool IntegerCompare(int Lvalue,
 	int Rvalue);
 void GetItemName(UnitItemInfo* uInfo,
 	string& name);
+void TrimItemText(UnitItemInfo* uInfo,
+	string& name,
+	BOOL bLimit);
 void SubstituteNameVariables(UnitItemInfo* uInfo,
 	string& name,
 	const string& action_name,


### PR DESCRIPTION
* Properly replace %CL% when last rule not explicitly declared. (Basically EOF reached before lack of `%CONTINUE%`.)
* Fix `inShop` check for new lines. (Paired parenthesis wrong.)
* Fix named `STAT` variables that happened to be preceded with a % catching wrong.
* Trim item name/description text after all rules are processed instead of during every matched rule.
  * Fixes to-be-removed `%CL%` characters counting towards the limit.
  * Note: This uses the full 1024 limit (still hard-limiting here) while building a name, but limits it safely for display again afterwards.