### PR TITLE
Fix crash from empty item string

### DIFF
--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1384,7 +1384,7 @@ void TrimItemText(UnitItemInfo* uInfo,
 	// Delete leading/trailing CLs
 	if (name.find("\r") == 0)
 		name.erase(0, 1);
-	if (name.rfind("\r") == name.size() - 1)
+	if (!name.empty() && name.rfind("\r") == name.size() - 1)
 		name.resize(name.size() - 1);
 	// Convert to new line
 	while (name.find("\r") != string::npos)


### PR DESCRIPTION
When a single %CL% is the item name/description, this can result in a crash.