### PR TITLE
Attempt loading filter selected by PD2 launcher first

### DIFF
--- a/BH/BH.cpp
+++ b/BH/BH.cpp
@@ -71,16 +71,7 @@ void BH::Initialize()
 	App.config->LoadConfig();
 
 	lootFilter = new Config("loot.filter");
-	if (!lootFilter->Parse()) {
-		lootFilter->SetConfigName("default.filter");
-		if (!lootFilter->Parse()) {
-			string msg = "Could not find default loot filter.\nAttempted to load " +
-				path + "loot.filter (failed).\nAttempted to load " +
-				path + "default.filter (failed).\n\nDefaults loaded.";
-			MessageBox(NULL, msg.c_str(), "Failed to load ProjectDiablo lootFilter", MB_OK);
-		}
-	}
-
+	LoadLootFilter();
 
 	// Do this asynchronously because D2GFX_GetHwnd() will be null if
 	// we inject on process start
@@ -150,14 +141,15 @@ bool BH::Shutdown() {
 
 bool BH::ReloadConfig() {
 	if (initialized) {
-		if (D2CLIENT_GetPlayerUnit()) {
-			PrintText(0, "Reloading config: %s", App.config->GetConfigName().c_str());
-			PrintText(0, "Reloading filter: %s", lootFilter->GetConfigName().c_str());
-		}
 		App.config->LoadConfig();
-		lootFilter->Parse();
+		LoadLootFilter();
 		moduleManager->ReloadConfig();
 		statsDisplay->LoadConfig();
+
+		if (D2CLIENT_GetPlayerUnit()) {
+			PrintText(0, "Reloaded config: %s", App.config->GetConfigName().c_str());
+			PrintText(0, "Reloaded filter: %s", lootFilter->GetConfigName().c_str());
+		}
 
 		// Remove nodraw flag from items when filter is reloaded. This is primarily just a QoL feature.
 		// Otherwise you'd have to reload the filter + leave and rejoin the area for hidden items to be visible again
@@ -173,4 +165,42 @@ bool BH::ReloadConfig() {
 		}
 	}
 	return true;
+}
+
+void BH::LoadLootFilter()
+{
+	std::ifstream launcherConfig("./AppData/launcherSettings.json");
+	if (launcherConfig)
+	{
+		try
+		{
+			nlohmann::json launcherJson = nlohmann::json::parse(launcherConfig);
+			if (launcherJson.contains("SelectedAuthorAndFilter"))
+			{
+				std::string author = launcherJson["SelectedAuthorAndFilter"]["selectedAuthor"]["author"].template get<std::string>();
+				std::string filter = launcherJson["SelectedAuthorAndFilter"]["selectedFilter"]["name"].template get<std::string>();
+
+				if (author == "Local Filter") { lootFilter->SetConfigName("filters\\local\\" + filter); }
+				else { lootFilter->SetConfigName("filters\\online\\" + filter); }
+			}
+		}
+		catch (const json::parse_error&) {
+		}
+	}
+
+	if (!lootFilter->Parse())
+	{
+		// Fallback to previous behavior
+		lootFilter->SetConfigName("loot.filter");
+		if (!lootFilter->Parse())
+		{
+			lootFilter->SetConfigName("default.filter");
+			if (!lootFilter->Parse()) {
+				string msg = "Could not find default loot filter.\nAttempted to load " +
+					path + "loot.filter (failed).\nAttempted to load " +
+					path + "default.filter (failed).\n\nDefaults loaded.";
+				MessageBox(NULL, msg.c_str(), "Failed to load ProjectDiablo lootFilter", MB_OK);
+			}
+		}
+	}
 }

--- a/BH/BH.h
+++ b/BH/BH.h
@@ -36,6 +36,8 @@ namespace BH {
 	extern "C" __declspec(dllexport) void Initialize();
 	extern bool Shutdown();
 	extern bool ReloadConfig();
+	
+	void LoadLootFilter();
 };
 
 struct BHApp {


### PR DESCRIPTION
With the removal of the symlink used by the old launcher, the local filter editing process has gotten...much more involved. Requiring either a re-copy of the filter via the launcher with each edit or editing of the main `loot.filter` and remembering to copy it into the local folder before the next run (lest the edited `loot.filter` be overwritten).

The idea behind this change is to load the launcher-selected filter directly, falling back to the current behavior of the root `loot.filter` then `default.filter` files in the events the launcher config can't be loaded or the expected filter doesn't exist.

A couple notes:

* This *does* depend on the launcher config staying in the same place it's at now, with the same setting names. With it being as young as it is, I get that this may be subject to change.
* I also wasn't sure if this made more sense to be left in `BH` where the current loading is, or put into `Config` where...well...the config stuff is.
* If a launcher-selected filter loads properly on launch and the launcher config is then ruined in some way, reloading will continue to use the same filter file instead of immediately falling back, assuming it's still valid. I'm on the fence as to whether or not this is intuitive behavior. 