### PR TITLE
Fix map id lookup in conditions

### DIFF
--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -2562,19 +2562,8 @@ bool MapIdCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	Condition* arg1,
 	Condition* arg2)
 {
-	UnitAny* player = D2CLIENT_GetPlayerUnit();
-
-	if (player &&
-		player->pAct &&
-		player->pAct->pRoom1 &&
-		player->pAct->pRoom1->pRoom2 &&
-		player->pAct->pRoom1->pRoom2->pLevel &&
-		player->pAct->pRoom1->pRoom2->pLevel->dwLevelNo > 0)
-	{
-		int map_id = (int)player->pAct->pRoom1->pRoom2->pLevel->dwLevelNo;
-		return IntegerCompare(map_id, operation, mapId, mapId2);
-	}
-	return false;
+	int map_id = **Var_D2CLIENT_MapId();
+	return IntegerCompare(map_id, operation, mapId, mapId2);
 }
 
 bool MapTierCondition::EvaluateInternal(UnitItemInfo* uInfo,


### PR DESCRIPTION
The new method is used by `StatsDisplay::OnDraw()`. Items such as tomes are not purged from the cache by mouse over.

https://github.com/Project-Diablo-2/BH/blob/db78198c4e08dc4692157efb5b618254427b632f/BH/Drawing/Stats/StatsDisplay.cpp#L364