### PR TITLE
Minor tweaks

### DIFF
--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -931,6 +931,14 @@ void __fastcall Item::ItemNamePatch(wchar_t* name, UnitAny* pItem, int nameSize)
 	// ÿc8 (orange)
 	// ÿc9 (yellow)
 
+	// Pre-trim "ending" color code that would otherwise be split into a partial code with
+	// the following conversion
+	int lastColorPos = itemName.rfind("ÿc");
+	if (lastColorPos != string::npos && lastColorPos > nameSize - 6)
+	{
+		itemName.resize(lastColorPos);
+	}
+
 	// The game adds the item color code _after_ this ItemNamePatch intercept, so we need to
 	// reduce the total allowed size to account for this
 	MultiByteToWideChar(CODE_PAGE, MB_PRECOMPOSED, itemName.c_str(), -1, name, nameSize - 4);

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -2810,23 +2810,9 @@ bool EquippedCondition::EvaluateInternal(UnitItemInfo* uInfo,
 	Condition* arg2)
 {
 	bool is_equipped = false;
-	if (uInfo->item->pItemData->pOwnerInventory)
+	if (uInfo->item->pItemData->BodyLocation > 0 && uInfo->item->pItemData->ItemLocation == STORAGE_NULL)
 	{
-		UnitAny* pMerc = nullptr;
-		UnitAny* pPlayer = D2CLIENT_GetPlayerUnit();
-		if (D2CLIENT_GetUIState(UI_MERC))
-		{
-			pMerc = D2CLIENT_GetMercUnit();
-		}
-
-		if ((pPlayer && uInfo->item->pItemData->pOwnerInventory->dwOwnerId == pPlayer->dwUnitId) ||
-			(pMerc && uInfo->item->pItemData->pOwnerInventory->dwOwnerId == pMerc->dwUnitId))
-		{
-			if (uInfo->item->pItemData->BodyLocation > 0 && uInfo->item->pItemData->ItemLocation == STORAGE_NULL)
-			{
-				is_equipped = true;
-			}
-		}
+		is_equipped = true;
 	}
 
 	return IntegerCompare(is_equipped, (BYTE)EQUAL, 1);

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1563,7 +1563,7 @@ namespace ItemDisplay
 			item->ItemFilterNames.push_back(to_string(i + 1) + " - " + filterDefinitions[i].second);
 
 			// Max 9 entries
-			if (i >= 8) {
+			if (i >= 11) {
 				break;
 			}
 		}

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1303,31 +1303,13 @@ void SubstituteNameVariables(UnitItemInfo* uInfo,
 	bool inShop = (uInfo->item->pItemData->pOwnerInventory != 0 && // Skip on ground items
 		find(begin(ShopNPCs), end(ShopNPCs), uInfo->item->pItemData->pOwnerInventory->pOwner->dwTxtFileNo) != end(ShopNPCs));
 
-	// Concat replacements list into a regex string to avoid accidental matches with stray % symbols
-	string reListString = "";
-	for (int n = 0; n < sizeof(replacements) / sizeof(replacements[0]); n++)
+	for (ActionReplace replacement : replacements)
 	{
-		reListString += replacements[n].key;
-		if (n < sizeof(replacements) / sizeof(replacements[0]) - 1)
-			reListString += "|";
-	}
-
-	std::regex  var_reg("%(" + reListString + ")%", std::regex_constants::ECMAScript);
-	std::smatch var_match;
-
-
-	while (std::regex_search(name, var_match, var_reg))
-	{
-		string varString = var_match[1];
-		transform(varString.begin(), varString.end(), varString.begin(), ::toupper);
-		for (int n = sizeof(replacements) / sizeof(replacements[0]) - 1; n >= 0; --n) // Reverse order to avoid intercepting matches (eg RANGE vs ORANGE)
+		string varString = "%" + replacement.key + "%";
+		while (name.find(varString) != string::npos)
 		{
-			while (varString.find(replacements[n].key) != string::npos)
-			{
-				varString.replace(varString.find(replacements[n].key), replacements[n].key.length(), replacements[n].value);
-			}
+			name.replace(name.find(varString), varString.length(), replacement.value);
 		}
-		name.replace(name.find(var_match[0]), var_match[0].length(), varString);
 	}
 
 	// TODO: Unify handling of numbered and non-numbered variables


### PR DESCRIPTION
Seemed small enough to throw into another batch PR. Will split if preferred.

* Color code truncation fix
   * Check for a color code that would be split by existing truncation; move the cut-off point if necessary
   * See [Discord report](https://discord.com/channels/701658302085595158/771820538502971402/1234196452436344933) for example scenario
* `EQUIPPED` matching adjust to be owner agnostic
    * See [Discord report](https://discord.com/channels/701658302085595158/771820538502971402/1234295849626894376) and [Discord follow-up](https://discord.com/channels/701658302085595158/771820538502971402/1234411462018076693) for brief summary
* Filter level limit bump from 9 to 12
    * With a BH window near the top of the screen, this vertically puts us just above the bottom panel of the game. While there *is* room for more, this is definitely a good caution point.
    * Minor note: There's no direct hotkey combination for filter levels 10 - 12. It didn't seem worth changing the numpad interaction on people, but could in theory be set to Ctrl + Function key to still cover them all.
* Infinite loop fix
    * Remnants of a retrofitted/planned PR that I didn't properly clean up
    * Ditches one more regex use (yay)
    * See #54