### PR TITLE
Prevent underflow, ensure buffer has enough space for ilvl

### DIFF
--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -1953,14 +1953,14 @@ void __stdcall Item::OnProperties(wchar_t* wTxt)
 		// Add alvl
 		if (ilvl != alvl && (quality == ITEM_QUALITY_MAGIC || quality == ITEM_QUALITY_RARE || quality == ITEM_QUALITY_CRAFT)) {
 			int aLen = wcslen(wTxt);
-			if (aLen < ITEM_TEXT_SIZE_LIMIT && alvlLen + 1 < ITEM_TEXT_SIZE_LIMIT - aLen) {
+			if (aLen < ITEM_TEXT_SIZE_LIMIT && alvlLen < ITEM_TEXT_SIZE_LIMIT - aLen) {
 				swprintf_s(wTxt + aLen, ITEM_TEXT_SIZE_LIMIT - aLen, alvlString);
 			}
 		}
 
 		// Add ilvl
 		int aLen = wcslen(wTxt);
-		if (aLen < ITEM_TEXT_SIZE_LIMIT && ilvlLen + 1 < ITEM_TEXT_SIZE_LIMIT - aLen) {
+		if (aLen < ITEM_TEXT_SIZE_LIMIT && ilvlLen < ITEM_TEXT_SIZE_LIMIT - aLen) {
 			swprintf_s(wTxt + aLen, ITEM_TEXT_SIZE_LIMIT - aLen, ilvlString);
 		}
 	}

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -1892,11 +1892,13 @@ void __stdcall Item::OnProperties(wchar_t* wTxt)
 				auto chars_written = MultiByteToWideChar(CODE_PAGE, MB_PRECOMPOSED, desc.c_str(), -1, wDesc, MAX_ITEM_TEXT_SIZE);
 
 				int aLen = wcslen(wTxt);
-				swprintf_s(wTxt + aLen, ITEM_TEXT_SIZE_LIMIT - aLen,
-					L"%s%s\n",
-					(chars_written > 0) ? wDesc : L"\377c1Item Description is too long.",
-					GetColorCode(TextColor::White).c_str()
-				);
+				if (aLen < ITEM_TEXT_SIZE_LIMIT) {
+					swprintf_s(wTxt + aLen, ITEM_TEXT_SIZE_LIMIT - aLen,
+						L"%s%s\n",
+						(chars_written > 0) ? wDesc : L"\377c1Item Description is too long.",
+						GetColorCode(TextColor::White).c_str()
+					);
+				}
 			}
 		}
 	}
@@ -1951,12 +1953,16 @@ void __stdcall Item::OnProperties(wchar_t* wTxt)
 		// Add alvl
 		if (ilvl != alvl && (quality == ITEM_QUALITY_MAGIC || quality == ITEM_QUALITY_RARE || quality == ITEM_QUALITY_CRAFT)) {
 			int aLen = wcslen(wTxt);
-			swprintf_s(wTxt + aLen, ITEM_TEXT_SIZE_LIMIT - aLen, alvlString);
+			if (aLen < ITEM_TEXT_SIZE_LIMIT && alvlLen + 1 < ITEM_TEXT_SIZE_LIMIT - aLen) {
+				swprintf_s(wTxt + aLen, ITEM_TEXT_SIZE_LIMIT - aLen, alvlString);
+			}
 		}
 
 		// Add ilvl
 		int aLen = wcslen(wTxt);
-		swprintf_s(wTxt + aLen, ITEM_TEXT_SIZE_LIMIT - aLen, ilvlString);
+		if (aLen < ITEM_TEXT_SIZE_LIMIT && ilvlLen + 1 < ITEM_TEXT_SIZE_LIMIT - aLen) {
+			swprintf_s(wTxt + aLen, ITEM_TEXT_SIZE_LIMIT - aLen, ilvlString);
+		}
 	}
 }
 


### PR DESCRIPTION
`swprintf_s` invokes an invalid parameter handler if there is not enough space in the buffer to write all the characters [1]. This crashes the game. There's a really long description for some plugy testing charms. This avoids those crashes.

There is a potential underflow if the text length is longed than the limit.

[1] https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/sprintf-s-sprintf-s-l-swprintf-s-swprintf-s-l?view=msvc-170#remarks
