### PR TITLE
Allow alias use in filters

### DIFF
--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -928,6 +928,7 @@ extern vector<Rule*>                RuleList;
 extern vector<Rule*>                MapRuleList;
 extern vector<Rule*>                IgnoreRuleList;
 extern vector<pair<string, string>> rules;
+extern vector<pair<string, string>> aliases;
 extern ItemDescLookupCache          item_desc_cache;
 extern ItemNameLookupCache          item_name_cache;
 extern MapActionLookupCache         map_action_cache;


### PR DESCRIPTION
A simple find/replace alias approach similar to bash aliases. Applying to either conditions or output strings on filter load (rather than on item/name generation).

A very basic example:
```swift
Alias[rangedWeapons]: BOW OR XBOW OR THROWING OR aqv OR cqv
Alias[DONTPICKUP]: ignore these things >>

ItemDisplay[NMAG rangedWeapons]: %DONTPICKUP% %NAME% //  ignore these things >> arrows
```

I left out any alias-in-alias recursion for now. Partly because of excessive load time impact worries, partly because I just don't wanna right now.

Minor caveats to be shared with usage: Aliases *are* case sensitive as conditions, and *need* to  be all caps as output variables. If case insensitivity seems needed, it can be added, but I'd rather do that in addition to making the rest of the filter stuff fully case insensitive.