### PR TITLE
Fix prematurely hiding loot items

### DIFF
--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -1047,10 +1047,13 @@ void Item::ProcessItemPacketFilterRules(UnitItemInfo* uInfo, px9c* pPacket)
 		else if (!showOnMap) {
 			for (vector<Rule*>::iterator it = RuleList.begin(); it != RuleList.end(); it++) {
 				if ((*it)->Evaluate(uInfo)) {
-					if ((*it)->action.name.length() == 0 && Item::GetFilterLevel() > 0) {
-						uInfo->item->dwFlags2 |= UNITFLAGEX_INVISIBLE;
+					if ((*it)->action.stopProcessing)
+					{
+						if ((*it)->action.name.length() == 0 && Item::GetFilterLevel() > 0) {
+							uInfo->item->dwFlags2 |= UNITFLAGEX_INVISIBLE;
+						}
+						break;
 					}
-					if ((*it)->action.stopProcessing) break;
 				}
 			}
 		}


### PR DESCRIPTION
Currently items are hidden if any rule that catches them doesn't contain a name string, even if a later rule applies a name.
See report in Discord [here](https://discord.com/channels/701658302085595158/771820538502971402/1302854761544024196).

This holds the flag assignment off until the item's done being evaluated through rules and *then* applies if necessary.