### PR TITLE
Fix %ALVL% output

### DIFF
--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1477,8 +1477,8 @@ string NameVarAlvl(UnitItemInfo* uInfo)
 {
 	char alvl[4] = "0";
 	int alvl_int = GetAffixLevel(
-		uInfo->attrs->qualityLevel,
 		uInfo->item->pItemData->dwItemLevel,
+		uInfo->attrs->qualityLevel,
 		uInfo->attrs->magicLevel
 	);
 	sprintf_s(alvl, "%d", alvl_int);


### PR DESCRIPTION
Puts parameters for `GetAffixLevel` back in the correct order.
I messed this one up with one of the commits in #47 and never noticed.