### PR TITLE
Prevent Alias substring matching

### DIFF
--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1750,6 +1750,12 @@ namespace ItemDisplay
 				size_t pos = rules[i].first.find(alias.first);
 				while (pos != string::npos)
 				{
+					if (pos == 0)
+					{
+						rules[i].first.replace(pos, alias.first.length(), alias.second);
+						pos = rules[i].first.find(alias.first, pos + 1);
+						continue;
+					}
 					// Expand alias only on full matches (i.e. skip if only a substring)
 					if ((rules[i].first[pos - 1] == '(' || rules[i].first[pos - 1] == ' ') &&
 						(rules[i].first[pos + alias.first.length()] == ')' || rules[i].first[pos + alias.first.length()] == ' '))

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1747,8 +1747,17 @@ namespace ItemDisplay
 				if (alias.first.empty())
 					continue;
 
-				while (rules[i].first.find(alias.first) != string::npos)
-					rules[i].first.replace(rules[i].first.find(alias.first), alias.first.length(), alias.second);
+				size_t pos = rules[i].first.find(alias.first);
+				while (pos != string::npos)
+				{
+					// Expand alias only on full matches (i.e. skip if only a substring)
+					if ((rules[i].first[pos - 1] == '(' || rules[i].first[pos - 1] == ' ') &&
+						(rules[i].first[pos + alias.first.length()] == ')' || rules[i].first[pos + alias.first.length()] == ' '))
+					{
+						rules[i].first.replace(pos, alias.first.length(), alias.second);
+					}
+					pos = rules[i].first.find(alias.first, pos + 1);
+				}
 
 				transform(alias.first.begin(), alias.first.end(), alias.first.begin(), toupper);
 				while (rules[i].second.find("%" + alias.first + "%") != string::npos)


### PR DESCRIPTION
Initial implementation apparently wasn't as intuitive as I'd hoped. It allowed some make-shift recursion if used in reverse, but prevented short alias names being expanded on.

First report of substring matching being an issue in Discord [here](https://discord.com/channels/701658302085595158/771820538502971402/1299659622923108352) (example given summarized below) with a few later questions about the same thing.

```
// Tests: automod levels
Alias[SINAM3]:    (...some skill list...)
Alias[SINAM3ATK]: (...some skill list...)
Alias[SINAM3SPL]: (...some skill list...)

// Labels: +skill tag
ItemDisplay[NMAG SIN (SINAM3)]:    %NAME% SKILLS{%NAME%}%CONTINUE%
ItemDisplay[NMAG SIN (SINAM3ATK)]: %NAME% ATTACK{%NAME%}%CONTINUE% // SINAM3 unintentionally matching here
ItemDisplay[NMAG SIN (SINAM3SPL)]: %NAME% SPELL{%NAME%}%CONTINUE% // SINAM3 also matching here

// Unintended matches replaced the text, also preventing the correct alias from matching
```

This was only a concern with the condition side of aliases, as the output side required the surrounding `%` in its match.
