### PR TITLE
Primitive loot filter sounds using any sound index in the Sounds.txt.

### DIFF
--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1770,7 +1770,8 @@ namespace ItemDisplay
 				r->action.borderColor != UNDEFINED_COLOR ||
 				r->action.dotColor != UNDEFINED_COLOR ||
 				r->action.pxColor != UNDEFINED_COLOR ||
-				r->action.lineColor != UNDEFINED_COLOR) {
+				r->action.lineColor != UNDEFINED_COLOR ||
+				r->action.soundID != -1) {
 				MapRuleList.push_back(r);
 			}
 			else if (r->action.name.length() == 0) { IgnoreRuleList.push_back(r); }
@@ -1971,6 +1972,7 @@ void BuildAction(string* str,
 	act->notifyColor = ParseMapColor(act, "NOTIFY");
 	act->pingLevel = ParsePingLevel(act, "TIER");
 	act->description = ParseDescription(act);
+	act->soundID = ParseSoundID(act, "SOUNDID");
 
 	// legacy support:
 	size_t map = act->name.find("%MAP%");
@@ -2018,6 +2020,21 @@ int ParsePingLevel(Action* act, const string& key_string) {
 			the_match[0].length(), "");
 	}
 	return ping_level;
+}
+
+int ParseSoundID(Action* act, const string& key_string) {
+	std::regex pattern("%" + key_string + "-([0-9]{1,9})%",
+		std::regex_constants::ECMAScript | std::regex_constants::icase);
+	int soundID = -1;
+	std::smatch the_match;
+
+	if (std::regex_search(act->name, the_match, pattern)) {
+		soundID = stoi(the_match[1].str());
+		act->name.replace(
+			the_match.prefix().length(),
+			the_match[0].length(), "");
+	}
+	return soundID;
 }
 
 string ParseDescription(Action* act)

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1771,7 +1771,7 @@ namespace ItemDisplay
 				r->action.dotColor != UNDEFINED_COLOR ||
 				r->action.pxColor != UNDEFINED_COLOR ||
 				r->action.lineColor != UNDEFINED_COLOR ||
-				r->action.soundID != -1) {
+				r->action.soundID != 0) {
 				MapRuleList.push_back(r);
 			}
 			else if (r->action.name.length() == 0) { IgnoreRuleList.push_back(r); }

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -2022,18 +2022,30 @@ int ParsePingLevel(Action* act, const string& key_string) {
 	return ping_level;
 }
 
+// ParseSoundID
+// Returns an int ranging from 0 to the MAX_SOUND_ID.
+// If the parsed soundID is not found in that range, this will return a 0.
 int ParseSoundID(Action* act, const string& key_string) {
-	std::regex pattern("%" + key_string + "-([0-9]{1,9})%",
+	std::regex pattern("%" + key_string + "-([0-9]{1,4})%",
 		std::regex_constants::ECMAScript | std::regex_constants::icase);
-	int soundID = -1;
+	// Default soundID should be 0 incase this is played.
+	// 0 is none.wav
+	int soundID = 0;
 	std::smatch the_match;
 
 	if (std::regex_search(act->name, the_match, pattern)) {
-		soundID = stoi(the_match[1].str());
+		int matchedSoundID = stoi(the_match[1].str());
 		act->name.replace(
 			the_match.prefix().length(),
 			the_match[0].length(), "");
+
+		// Do our best to ensure the soundID is valid.
+		// Ensure soundID is in the range of 0 and MAX_SOUND_ID.
+		if (matchedSoundID <= MAX_SOUND_ID) {
+			soundID = matchedSoundID;
+		}
 	}
+
 	return soundID;
 }
 

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -824,6 +824,7 @@ struct Action
 	int    lineColor;
 	int    notifyColor;
 	int pingLevel;
+	int soundID;
 
 	Action() :
 		colorOnMap(UNDEFINED_COLOR),
@@ -832,6 +833,7 @@ struct Action
 		pxColor(UNDEFINED_COLOR),
 		lineColor(UNDEFINED_COLOR),
 		notifyColor(UNDEFINED_COLOR),
+		soundID(-1),
 		pingLevel(-1),
 		stopProcessing(true),
 		name(""),
@@ -942,6 +944,7 @@ namespace ItemDisplay
 void            BuildAction(string* str,
 	Action* act);
 int ParsePingLevel(Action* act, const string& reg_string);
+int ParseSoundID(Action* act, const string& reg_string);
 string ParseDescription(Action* act);
 int    ParseMapColor(Action* act,
 	const string& reg_string);

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -825,7 +825,7 @@ struct Action
 	int    lineColor;
 	int    notifyColor;
 	int pingLevel;
-	int soundID; // Must be between 0 and MAX_SOUND_ID
+	int soundID; // Must range from 0 to MAX_SOUND_ID.
 
 	Action() :
 		colorOnMap(UNDEFINED_COLOR),

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -15,6 +15,7 @@
 #define EXCEPTION_INVALID_ITEM_TYPE		5
 #define EXCEPTION_INVALID_GOLD_TYPE		6
 
+#define MAX_SOUND_ID      4713 // Max sound index in Sounds.txt
 #define DEAD_COLOR        0xdead
 #define UNDEFINED_COLOR   0xbeef
 
@@ -824,7 +825,7 @@ struct Action
 	int    lineColor;
 	int    notifyColor;
 	int pingLevel;
-	int soundID;
+	int soundID; // Must be between 0 and MAX_SOUND_ID
 
 	Action() :
 		colorOnMap(UNDEFINED_COLOR),
@@ -833,7 +834,7 @@ struct Action
 		pxColor(UNDEFINED_COLOR),
 		lineColor(UNDEFINED_COLOR),
 		notifyColor(UNDEFINED_COLOR),
-		soundID(-1),
+		soundID(0),
 		pingLevel(-1),
 		stopProcessing(true),
 		name(""),

--- a/BH/Modules/MapNotify/MapNotify.cpp
+++ b/BH/Modules/MapNotify/MapNotify.cpp
@@ -83,6 +83,12 @@ void MapNotify::OnDraw() {
 								App.lootfilter.enableFilter.value && App.lootfilter.detailedNotifications.value != 0 &&
 								(App.lootfilter.detailedNotifications.value == 1 || (dwFlags & ITEM_NEW)))
 							{
+								// Play sound associated with the action.
+								int soundID = (*it)->action.soundID;
+								if (soundID >= 0) {
+									D2CLIENT_PlaySound_STUB(soundID, NULL, 0, 0, 0);
+								}
+
 								std::string itemName = GetItemName(unit);
 								regex trimName("^\\s*(?:(?:\\s*?)(ÿc[0123456789;:]))*\\s*(.*?\\S)\\s*(?:ÿc[0123456789;:])*\\s*$");	// Matches on leading/trailing spaces (skips most color codes)
 								itemName = regex_replace(itemName, trimName, "$1$2");												// Trims the matched spaces from notifications

--- a/BH/Modules/MapNotify/MapNotify.cpp
+++ b/BH/Modules/MapNotify/MapNotify.cpp
@@ -85,7 +85,8 @@ void MapNotify::OnDraw() {
 							{
 								// Play sound associated with the action.
 								int soundID = (*it)->action.soundID;
-								if (soundID >= 0) {
+								// SoundID 0 is none.wav, skip
+								if (soundID != 0) {
 									D2CLIENT_PlaySound_STUB(soundID, NULL, 0, 0, 0);
 								}
 


### PR DESCRIPTION
Adds primitive loot filter sounds.

We have a new notification code %SOUNDID-1337% where 1337 is the index of the sound in sounds.txt

Below is a test using the a modified version of the HIIM filter with these two modified lines.
On lower level filters we will play a moo, on higher we will play a jewel sound when a full rejuvenation potion drops. 

`
ItemDisplay[rvl FILTLVL<3]: %SOUNDID-1337%%BORDER-68%%PURPLE%*  %WHITE%Rejuv %PURPLE%65%  %PURPLE%*
ItemDisplay[rvl FILTLVL<7]: %SOUNDID-226%%PURPLE%*    %WHITE%Rejuv %PURPLE%65%%PURPLE%    *
`

Any sound notification will also result a print in the notifications. I think this is a solid behavior choice as we match the mini map drop notification behavior.  This is also matches same behavior in another D2 mod. There are solutions we can do later if we choose to separate that behavior, such as making the drop notification a separate notification type. 

See https://streamable.com/e760ob 