### PR TITLE
feat: automatically show automap when joining a game

### DIFF
--- a/BH/BH.h
+++ b/BH/BH.h
@@ -153,6 +153,7 @@ struct BHApp
 		};
 		SettingsAssoc additionalStats = {};
 		SettingsBool hideGamePassword = { false, false };
+		SettingsBool showAutomapOnJoin = { false, false };
 	} screen;
 
 	struct

--- a/BH/Config.cpp
+++ b/BH/Config.cpp
@@ -250,6 +250,7 @@ void Config::SaveConfig()
 	jsonScreen["automap_info"] = App.screen.automapInfo.values;
 	if (App.screen.additionalStats.values.size() > 0) { jsonScreen["additional_stats"] = App.screen.additionalStats.values; }
 	jsonScreen["hide_game_password"] = App.screen.hideGamePassword.value;
+	jsonScreen["show_automap_on_join"] = App.screen.showAutomapOnJoin.value;
 	App.jsonConfig["screen_info"] = jsonScreen;
 
 	// Stash Export
@@ -399,6 +400,7 @@ void Config::LoadConfig()
 	App.screen.automapInfo.values = GetArray("/screen_info"_json_pointer, "automap_info", App.screen.automapInfo);
 	App.screen.additionalStats.values = GetAssoc("/screen_info"_json_pointer, "additional_stats", App.screen.additionalStats);
 	App.screen.hideGamePassword.value = GetBool("/screen_info"_json_pointer, "hide_game_password", App.screen.hideGamePassword);
+	App.screen.showAutomapOnJoin.value = GetBool("/screen_info"_json_pointer, "show_automap_on_join", App.screen.showAutomapOnJoin);
 
 	// Stash Export
 	App.stash.includeEquipment.toggle = GetToggle("/stash_export"_json_pointer, "include_equipment", App.stash.includeEquipment);

--- a/BH/Modules/ScreenInfo/ScreenInfo.cpp
+++ b/BH/Modules/ScreenInfo/ScreenInfo.cpp
@@ -49,6 +49,10 @@ void ScreenInfo::LoadConfig()
 
 void ScreenInfo::OnGameJoin()
 {
+	if (App.screen.showAutomapOnJoin.value) {
+		*p_D2CLIENT_AutomapOn = 1;
+	}
+
 	BnetData* pInfo = (*p_D2LAUNCH_BnData);
 	UnitAny* unit = D2CLIENT_GetPlayerUnit();
 	/*if (unit) {


### PR DESCRIPTION
Hi!

I was wondering if something like this could be added. As far as I know there is no existing setting in D2/PD2 which would automatically show the automap when joining/creating a new game. I know it takes just one key stroke to open it, but it would still be a QoL change for me if I didn't have to do it every game :).

Thanks!