### PR TITLE
feat: add %BASENAME% replacement keyword

### DIFF
--- a/BH/Common.cpp
+++ b/BH/Common.cpp
@@ -124,6 +124,14 @@ int StringToNumber(std::string str) {
 	return ret;
 }
 
+std::string MaybeStripColorPrefix(std::string str) {
+	if (str.size() > 3 && str.substr(0, 2) == "ÿc") {
+		str = str.substr(3, str.size() - 3);
+	}
+
+	return str;
+}
+
 // This function prints at most 151 characters (152 including null)
 // TODO: Fix this so this limitation
 void PrintText(DWORD Color, char* szText, ...) {

--- a/BH/Common.h
+++ b/BH/Common.h
@@ -70,6 +70,7 @@ template< class type> std::string to_string(const type& value)
 bool IsTrue(const char* str);
 bool StringToBool(std::string str);
 int StringToNumber(std::string str);
+std::string MaybeStripColorPrefix(std::string str);
 
 std::string Trim(std::string source);
 

--- a/BH/Modules/Item/Item.h
+++ b/BH/Modules/Item/Item.h
@@ -130,7 +130,7 @@ bool IsInitialized();
 
 // Item attributes from ItemTypes.txt and Weapon/Armor/Misc.txt
 struct ItemAttributes {
-	std::string name;			// Only used in Item Drop/Item Close Notifications. Can delete
+	std::string name;
 	WORD category;
 	BYTE width;					// Delete. Inventory related, which is unnecessary
 	BYTE height;				// Delete. Inventory related, which is unnecessary

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -813,6 +813,8 @@ struct ReplacementSpec {
 	static string ReplaceConst(ReplaceContext& ctx, const ReplacementValue& val);
 	// %NAME%
 	static string ReplaceName(ReplaceContext& ctx, const ReplacementValue& val);
+	// %BASENAME%
+	static string ReplaceBaseName(ReplaceContext& ctx, const ReplacementValue& val);
 	// %SOCKETS%
 	static string ReplaceSockets(ReplaceContext& ctx, const ReplacementValue& val);
 	// %RUNENUM%
@@ -876,6 +878,7 @@ struct ReplacementSpec {
 unordered_map<string, ReplacementSpec> ReplacementMap = {
 	// STATIC
 	{ "NAME", { 0, ReplacementSpec::ReplaceName } },
+	{ "BASENAME", { 0, ReplacementSpec::ReplaceBaseName } },
 	{ "SOCKETS", { 0, ReplacementSpec::ReplaceSockets } },
 	{ "RUNENUM", { 0, ReplacementSpec::ReplaceRuneNumber } },
 	{ "RUNENAME", { 0, ReplacementSpec::ReplaceRuneName } },
@@ -1047,6 +1050,15 @@ string ReplacementSpec::ReplaceName(ReplaceContext& ctx, const ReplacementValue&
 		ctx.name.resize(1023);
 	}
 	return ctx.name;
+}
+
+string ReplacementSpec::ReplaceBaseName(ReplaceContext& ctx, const ReplacementValue& val)
+{
+	if (ctx.info == nullptr || ctx.info->attrs == nullptr) {
+		return "";
+	}
+
+	return MaybeStripColorPrefix(ctx.info->attrs->name);
 }
 
 string ReplacementSpec::ReplaceSockets(ReplaceContext& ctx, const ReplacementValue& val)

--- a/BH/Modules/StashExport/StashExport.cpp
+++ b/BH/Modules/StashExport/StashExport.cpp
@@ -250,9 +250,7 @@ void StashExport::GetItemInfo(UnitAny* pItem, JSONObject* pBuffer) {
 	ItemsTxt* txt = D2COMMON_GetItemText(pItem->dwTxtFileNo);
 	std::string type = UnicodeToAnsi(D2LANG_GetLocaleText(txt->wnamestr));
 	// Remove hardcoded color
-	if (type.size() > 3 && type.substr(0, 2) == "ÿc") {
-		type = type.substr(3, type.size() - 3);
-	}
+	type = MaybeStripColorPrefix(type);
 	pBuffer->set("type", type);
 	pBuffer->set("quality", std::string(QUALITY_NAMES[pItem->pItemData->dwQuality]));
 	pBuffer->set("iLevel", (int)pItem->pItemData->dwItemLevel);
@@ -321,9 +319,7 @@ void StashExport::GetItemInfo(UnitAny* pItem, JSONObject* pBuffer) {
 			}
 
 			// Remove hardcoded color
-			if (name.size() > 3 && name.substr(0, 2) == "ÿc") {
-				name = name.substr(3, name.size() - 3);
-			}
+			name = MaybeStripColorPrefix(name);
 			pBuffer->set("name", name);
 		}
 							   break;
@@ -333,9 +329,7 @@ void StashExport::GetItemInfo(UnitAny* pItem, JSONObject* pBuffer) {
 			{
 				std::string name = pUniqueItemsTxt->szName;
 				// Remove hardcoded color
-				if (name.size() > 3 && name.substr(0, 2) == "ÿc") {
-					name = name.substr(3, name.size() - 3);
-				}
+				name = MaybeStripColorPrefix(name);
 				pBuffer->set("name", name);
 				fillStats(statsObject, pUniqueItemsTxt->hStats, pItem, 12);
 			}
@@ -349,9 +343,7 @@ void StashExport::GetItemInfo(UnitAny* pItem, JSONObject* pBuffer) {
 				std::string itemName = pSetItemsTxt->szName;
 				std::string setName = UnicodeToAnsi(GetTblEntryByIndex(pSetsTxt->wStringId, TBLOFFSET_STRING));
 				// Remove hardcoded color
-				if (itemName.size() > 3 && itemName.substr(0, 2) == "ÿc") {
-					itemName = itemName.substr(3, itemName.size() - 3);
-				}
+				itemName = MaybeStripColorPrefix(itemName);
 				pBuffer->set("set", setName);
 				pBuffer->set("name", itemName);
 				fillStats(statsObject, pSetItemsTxt->hStats, pItem, 9);


### PR DESCRIPTION
Hi!

In my custom filter I have dozens of lines of the following form:
```
(...)
ItemDisplay[wss]: Worldstone Shard%CONTINUE%
ItemDisplay[lbox]: Larzuk's Puzzlebox%CONTINUE%
ItemDisplay[lpp]: Larzuk's Puzzlepiece%CONTINUE%
ItemDisplay[rtp]: Horadrim Navigator%CONTINUE%
ItemDisplay[rid]: Horadrim Almanac%CONTINUE%
ItemDisplay[rkey]: Skeleton Key%CONTINUE%
ItemDisplay[lsvl]: Vial of Ligthsong%CONTINUE%
ItemDisplay[llmr]: Lilith's Mirror%CONTINUE%
(...)
ItemDisplay[!RW !UNI !SET ne1]: Preserved Head%CONTINUE%
ItemDisplay[!RW !UNI !SET ne2]: Zombie Head%CONTINUE%
ItemDisplay[!RW !UNI !SET ne3]: Unraveller Head%CONTINUE%
(...)
```
whose only purpose is to reset the color of the item name and potentially shorten it by removing the quality description prefix.
Having a keyword which, when used in a loot filter would be replaced by the corresponding item's base name (and potentially remove the hardcoded color), would greatly simplify my loot filter, but I think it would benefit other people as well. For example the following lines in popular loot filters could be simplified with it:
1. [Kryszard](https://github.com/Kryszard-POD/Kryszard-s-PD2-Loot-Filter/blob/20941753863add90dc172ae122271d02baa37e73/item.filter#L392-L885)
2. [Hiim](https://github.com/Maaaaaarrk/HiimFilter-PD2-Filter/blob/6c3d1e4be28c7422d93106f0408c8e567698a302/Hiim.filter#L1086-L1752)

# Proposal
I propose to add a new keyword `%BASENAME%` which would what I'm suggesting in the section above.

# Tests
Some examples of the following filter `ItemDisplay[]:%RED%%NAME% %GREEN%%BASENAME%` applied to several items:
1. The color is properly applied to the item name:
<img width="510" height="199" alt="base_name_1" src="https://github.com/user-attachments/assets/93ad832f-e717-4075-8cb0-e62c1c8b84e7" />

2. The item quality descriptor is omitted: 
<img width="387" height="103" alt="base_name_2" src="https://github.com/user-attachments/assets/9a0b7fb3-c579-4a64-8c29-a9ffbecee4bc" />

3. Interaction with unique names:
<img width="439" height="122" alt="base_name_3" src="https://github.com/user-attachments/assets/b5eec8b1-b865-4355-82c8-35e0025751de" />

