### PR TITLE
feat: introduce %REROLLALVL% keyword

### DIFF
--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -390,6 +390,25 @@ private:
 		Condition* arg2);
 };
 
+class RerollLevelCondition : public Condition
+{
+public:
+	RerollLevelCondition(BYTE operation,
+		BYTE rerollLevel1,
+		BYTE rerollLevel2) : operation_(operation),
+		rerollLevel1_(rerollLevel1),
+		rerollLevel2_(rerollLevel2) {
+		conditionType = CT_Operand;
+	};
+private:
+	BYTE operation_;
+	BYTE rerollLevel1_;
+	BYTE rerollLevel2_;
+	bool EvaluateInternal(UnitItemInfo* uInfo,
+		Condition* arg1,
+		Condition* arg2);
+};
+
 class AutomodCondition : public Condition
 {
 public:
@@ -961,6 +980,7 @@ string NameVarGemType(UnitItemInfo* uInfo);
 string NameVarIlvl(UnitItemInfo* uInfo);
 string NameVarAlvl(UnitItemInfo* uInfo);
 string NameVarCraftAlvl(UnitItemInfo* uInfo);
+string NameVarRerollAlvl(UnitItemInfo* uInfo);
 string NameVarLevelReq(UnitItemInfo* uInfo);
 string NameVarWeaponSpeed(ItemsTxt* itemTxt);
 string NameVarRangeAdder(ItemsTxt* itemTxt);
@@ -975,3 +995,4 @@ BYTE GetAffixLevel(BYTE ilvl,
 BYTE GetRequiredLevel(UnitAny* item);
 BYTE RuneNumberFromItemCode(char* code);
 int GetStatFromList(UnitItemInfo* uInfo, int itemStat);
+BYTE ComputeRerollAffixLevel(UnitItemInfo* uInfo);


### PR DESCRIPTION
I'm proposing to add a new keyword `REROLLALVL` which would be replaced by the affix level of the corresponding item after rerolling it using the standard recipe (i.e. 3 perfect games for magic and 3 perfect skulls for rare items). Something similar to the existing `CRAFTINGALVL`.

AFAIK, without this keyword, there is no easy way to achieve this in the current implementation of the filtering system.
For example, to determine whether the given rare jewel can be re-rolled by the current character into a 40ED jewel, one would have to explicitly list all pairs of jewel's ilvl and character's lvl, which would satisfy `(int)0.4ilvl + (int)0.4clvl >= 66`. 

# Tests
Given the following loot filter configuration
```
ItemDisplay[RARE jew REROLLALVL>65]: %NAME% %GREEN%Reroll!%CONTINUE%
ItemDisplay[RARE jew REROLLALVL<66]: %NAME% %RED%Don't Reroll!%CONTINUE%
ItemDisplay[RARE REROLLALVL>0]: %NAME% {%ORANGE% Affix Level After Reroll (3 p.skulls): %REROLLALVL%}%CONTINUE%
ItemDisplay[MAG REROLLALVL>0]: %NAME% {%ORANGE% Affix Level After Reroll (3 p.gems): %REROLLALVL%}%CONTINUE%
ItemDisplay[REROLLALVL=0]: %NAME% {%RED% Not Rerollable Via Standard Recipe}%CONTINUE%
``` 
hovering over several items gives:
<img width="406" height="202" alt="reroll_alvl_2" src="https://github.com/user-attachments/assets/1bafca00-4d70-4256-b914-f669610f270a" />
<img width="403" height="202" alt="reroll_alvl_3" src="https://github.com/user-attachments/assets/ff937c81-9a9f-41fd-a6c6-303aa53d28ba" />
<img width="506" height="225" alt="reroll_alvl_4" src="https://github.com/user-attachments/assets/5e3df4d4-d718-45d0-b959-390d61df9798" />
<img width="447" height="258" alt="reroll_alvl_5" src="https://github.com/user-attachments/assets/f9d220ee-55e4-4820-b6de-5897ed409b83" />
