### PR TITLE
feat: Add `TRUE` and `FALSE` keywords

### DIFF
--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -493,6 +493,8 @@ enum FilterCondition
 	COND_PRICE,
 	COND_ITEMCODE,
 	COND_ADD,
+	COND_TRUE,
+	COND_FALSE,
 
 	COND_NULL
 };
@@ -503,6 +505,8 @@ std::map<std::string, FilterCondition> condition_map =
 	{"&&", COND_AND},
 	{"OR", COND_OR},
 	{"||", COND_OR},
+	{"TRUE", COND_TRUE},
+	{"FALSE", COND_FALSE},
 	{"ETH", COND_ETH},
 	{"SOCK", COND_SOCK},
 	{"SOCKETS", COND_SOCK},
@@ -2285,6 +2289,12 @@ void Condition::BuildConditions(vector<Condition*>& conditions,
 	case COND_OR:
 		Condition::AddNonOperand(conditions, new OrOperator());
 		break;
+	case COND_TRUE:
+		Condition::AddOperand(conditions, new TrueCondition());
+		break;
+	case COND_FALSE:
+		Condition::AddOperand(conditions, new FalseCondition());
+		break;
 	case COND_ETH:
 		Condition::AddOperand(conditions, new FlagsCondition(ITEM_ETHEREAL));
 		break;
@@ -3393,4 +3403,3 @@ void HandleUnknownItemCode(char* code,
 		UnknownItemCodes[code] = 1;
 	}
 }
-


### PR DESCRIPTION
One more small proposal. I noticed that `TrueCondition` and `FalseCondition` classes exist in the code already, this PR takes advantage of them.

I want to be able to do something like this:
```
ItemDisplayFilterName[]: Without small pots
ItemDisplayFilterName[]: Only biggest pots

%%%% SETTINGS %%%%
Alias[FORCE_HIDE_HEALTH_POTS]: FALSE
Alias[FORCE_HIDE_MANA_POTS]: TRUE
Alias[SET_NOTIFICATIONS_ENABLED]: TRUE

%%%% HIDE %%%%
ItemDisplay[FORCE_HIDE_HEALTH_POTS (hp1 OR hp2 OR hp3 OR hp4 OR hp5)]:
ItemDisplay[FORCE_HIDE_MANA_POTS (mp1 OR mp2 OR mp3 OR mp4 OR mp5)]:
ItemDisplay[FILTLVL>0 (hp1 OR mp1 OR hp2 OR mp2 OR hp3 OR mp3)]:
ItemDisplay[FILTLVL>1 (hp1 OR mp1 OR hp2 OR mp2 OR hp3 OR mp3 OR hp4 OR mp4)]:

%%%% NOTIFICATIONS %%%%
ItemDisplay[SET_NOTIFICATIONS_ENABLED SET]: %PX-00%%NAME%%CONTINUE%
```

which would make my lootfilter a tad more readable :)