### PR TITLE
feat: add `BELTCOLUMN{1,2,3,4}` keywords

### DIFF
--- a/BH/Constants.h
+++ b/BH/Constants.h
@@ -762,6 +762,12 @@ enum PetType
 #define NODEPAGE_BELTSLOTS	2
 #define NODEPAGE_EQUIP		3
 
+enum InventoryStoreType {
+	INVENTORY_STORE_TYPE_BODY = 0,
+	INVENTORY_STORE_TYPE_BELT,
+	INVENTORY_STORE_TYPE_INVENTORY,
+};
+
 ///////////////////////////////////////////////////
 // Item Actions
 ///////////////////////////////////////////////////

--- a/BH/D2Structs.h
+++ b/BH/D2Structs.h
@@ -292,11 +292,11 @@ struct PlayerData {
 	DWORD _0x244;
 	DWORD _0x248;
 	DWORD _0x24C;
-	BOOL _0x250;				// 
+	BOOL _0x250;				//
 	DWORD _0x254;			//
 	DWORD _0x258;	//
 	DWORD _0x25C;	//
-	BOOL _0x260;				// 
+	BOOL _0x260;				//
 	BYTE _0x264;			//
 	BOOL _0x265;
 	DWORD _0x269;
@@ -460,7 +460,7 @@ struct InventoryStore
 	BYTE Width;						//0x08
 	BYTE Height;					//0x09
 	BYTE unk[2];					//0x0A
-	DWORD pArray;					//0x0C UnitAny* [height][width]
+	UnitAny** pArray;					//0x0C UnitAny* [height][width]
 };
 
 struct Inventory {
@@ -581,7 +581,7 @@ struct ItemText {
 	BYTE _uncharted6[0x0d];			//0xDF
 	BYTE fQuest;					//0xEC
 	BYTE _uncharted7[0x12];			//0xED
-	BYTE reqlvl;					//0xFF 
+	BYTE reqlvl;					//0xFF
 	BYTE magiclvl;					//0x100
 };
 
@@ -746,10 +746,10 @@ struct UnitAny {
 
 struct BnetData {
 	DWORD dwId;					//0x00
-	DWORD dwId2;				//0x04	
+	DWORD dwId2;				//0x04
 	BYTE _12[13];				//0xC0
 	//DWORD dwId3;				//0x14
-	//WORD Unk3;					//0x18	
+	//WORD Unk3;					//0x18
 	BYTE _13[6];				//0xC0
 	char szGameName[22];		//0x1A
 	char szGameIP[16];			//0x30

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -4,7 +4,6 @@
 #include "../../D2Helpers.h"
 #include "../../Common.h"
 #include <cctype>
-#include <cstddef>
 #include <vector>
 #include <string>
 #include <sstream>

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -4,6 +4,7 @@
 #include "../../D2Helpers.h"
 #include "../../Common.h"
 #include <cctype>
+#include <cstddef>
 #include <vector>
 #include <string>
 #include <sstream>
@@ -562,6 +563,10 @@ enum FilterCondition
 	COND_UPSTAT,
 	COND_MAXSOCKETS,
 	COND_FORMULA,
+	COND_BELT_1,
+	COND_BELT_2,
+	COND_BELT_3,
+	COND_BELT_4,
 
 	COND_NULL
 };
@@ -751,6 +756,10 @@ std::map<std::wstring, FilterCondition> condition_map =
 	{L"WIDTH", COND_WIDTH},
 	{L"HEIGHT", COND_HEIGHT},
 	{L"AREA", COND_AREA},
+	{L"BELTCOLUMN1", COND_BELT_1},
+	{L"BELTCOLUMN2", COND_BELT_2},
+	{L"BELTCOLUMN3", COND_BELT_3},
+	{L"BELTCOLUMN4", COND_BELT_4},
 	// These have a number as part of the key, handled separately
 	//{"SK", COND_SK},
 	//{"OS", COND_OS},
@@ -4323,6 +4332,18 @@ void Condition::BuildConditions(vector<Condition*>& conditions,
 	case COND_AREA:
 		Condition::AddOperand(conditions, new ItemSizeCondition(operation, value, value2, ItemSizeCondition::Dimension::kArea));
 		break;
+	case COND_BELT_1:
+		Condition::AddOperand(conditions, new BeltCondition(operation, value, value2, 0));
+		break;
+	case COND_BELT_2:
+		Condition::AddOperand(conditions, new BeltCondition(operation, value, value2, 1));
+		break;
+	case COND_BELT_3:
+		Condition::AddOperand(conditions, new BeltCondition(operation, value, value2, 2));
+		break;
+	case COND_BELT_4:
+		Condition::AddOperand(conditions, new BeltCondition(operation, value, value2, 3));
+		break;
 	case COND_ITEMCODE:
 		Condition::AddOperand(conditions, new ItemCodeCondition(WideToAnsi(key.substr(0, 4)).c_str()));
 		break;
@@ -5150,6 +5171,39 @@ bool ItemSizeCondition::EvaluateInternal(UnitItemInfo* uInfo, Condition* arg1, C
 	}
 
 	return IntegerCompare(value, op_, targetStat_, targetStat2_);
+}
+
+bool BeltCondition::EvaluateInternal(UnitItemInfo* uInfo, Condition* arg1, Condition* arg2)
+{
+	const int kBeltWidth = 4;
+	const int kBeltHeight = 4;
+
+	Inventory* inventory = D2CLIENT_GetPlayerUnit()->pInventory;
+	if (inventory == nullptr) {
+		return false;
+	}
+	if (column_ >= kBeltWidth) {
+		return false;
+	}
+	if (inventory->dwStoresCount <= InventoryStoreType::INVENTORY_STORE_TYPE_BELT) {
+		return false;
+	}
+	InventoryStore store = inventory->pStores[InventoryStoreType::INVENTORY_STORE_TYPE_BELT];
+	// Double check that this is indeed the correct `InventoryStore`.
+	// Internally belt is represented as a flat, 16 elements, array.
+	if (store.Width != kBeltWidth * kBeltHeight || store.Height != 1) {
+		return false;
+	}
+
+	int itemsInColumnCount = 0;
+	for (int row = 0; row < kBeltHeight; ++row) {
+		auto slot = row * kBeltWidth + column_;
+		if (store.pArray[slot] != nullptr) {
+			itemsInColumnCount += 1;
+		}
+	}
+
+	return IntegerCompare(itemsInColumnCount, op_, targetStat_, targetStat2_);
 }
 
 bool ResistAllCondition::EvaluateInternal(UnitItemInfo* uInfo,

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -5187,7 +5187,7 @@ bool BeltCondition::EvaluateInternal(UnitItemInfo* uInfo, Condition* arg1, Condi
 	if (inventory->dwStoresCount <= InventoryStoreType::INVENTORY_STORE_TYPE_BELT) {
 		return false;
 	}
-	InventoryStore store = inventory->pStores[InventoryStoreType::INVENTORY_STORE_TYPE_BELT];
+	InventoryStore& store = inventory->pStores[InventoryStoreType::INVENTORY_STORE_TYPE_BELT];
 	// Double check that this is indeed the correct `InventoryStore`.
 	// Internally belt is represented as a flat, 16 elements, array.
 	if (store.Width != kBeltWidth * kBeltHeight || store.Height != 1) {

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -799,6 +799,27 @@ private:
 	bool EvaluateInternal(UnitItemInfo* uInfo, Condition* arg1, Condition* arg2);
 };
 
+class BeltCondition: public Condition
+{
+public:
+	BeltCondition(BYTE op,
+		unsigned int targetStat,
+		unsigned int targetStat2,
+		unsigned int column)
+		: op_(op),
+		targetStat_(targetStat),
+		targetStat2_(targetStat2),
+		column_(column){
+		conditionType = CT_Operand;
+	};
+private:
+	BYTE op_;
+	unsigned int targetStat_;
+	unsigned int targetStat2_;
+	unsigned int column_;
+	bool EvaluateInternal(UnitItemInfo* uInfo, Condition* arg1, Condition* arg2);
+};
+
 class ResistAllCondition : public Condition
 {
 public:


### PR DESCRIPTION
Would it be possible to have something like this in pd2? 

I would like be able to hide potions on the ground if my belt is already full and only show them when there is a space for them in the designated column(s) of the belt. For example `BELTCOLUMN2>0` would match if there is at least one item in the second column in the belt.

It's probably a niche use-case, but I'd personally use it in my filter.

# Examples

```
Alias[HEALTH_POTS]: (hp1 OR hp2 OR hp3 OR hp4 OR hp5)
Alias[MANA_POTS]: (mp1 OR mp2 OR mp3 OR mp4 OR mp5)

% hide potions if the belt is full
ItemDisplay[(BELTCOLUMN1>3 BELTCOLUMN2>3) HEALTH_POTS]: %RED%would be hidden %WHITE%%NAME%
ItemDisplay[BELTCOLUMN3>3 MANA_POTS]: %RED%would be hidden %WHITE%%NAME%

% show potions if there is space in the belt (only works for belts with 4 rows)
ItemDisplay[(BELTCOLUMN1<4 OR BELTCOLUMN2<4) HEALTH_POTS): %GREEN%would be shown %WHITE%%NAME%
ItemDisplay[BELTCOLUMN3><4 MANA_POTS]: %GREEN%would be shown %WHITE%%NAME%
```

Space for mana pots:
<img width="584" height="655" alt="pots_1" src="https://github.com/user-attachments/assets/2a56dfb6-5d64-4c73-ad4a-961560c703fe" />

Space for health pots:
<img width="584" height="601" alt="pots_3" src="https://github.com/user-attachments/assets/371bd47f-97e1-4281-a8d1-082615ba685c" />

No space for any pots:
<img width="584" height="695" alt="pots_2" src="https://github.com/user-attachments/assets/862fc143-974c-40a3-82d7-66b1912f56c2" />

# Tests
I tested that this works with no belt, 2x4 belt, 4x4 belt

# Known limitations

Because of the caching, hidden potions won't become visible when the character drinks a potion from the belt, and vice-versa.